### PR TITLE
Add Relationships CRUD

### DIFF
--- a/components/RelationshipDialog.tsx
+++ b/components/RelationshipDialog.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Chip,
+  Box,
+  Typography,
+  IconButton,
+  Autocomplete,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+type Relationship = {
+  before: string;
+  after: string;
+  references: string[];
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSave: (rel: Relationship, originalBefore?: string, originalAfter?: string) => void;
+  relationship?: Relationship | null;
+  signNames: string[];
+};
+
+export default function RelationshipDialog({
+  open,
+  onClose,
+  onSave,
+  relationship,
+  signNames,
+}: Props) {
+  const [before, setBefore] = useState('');
+  const [after, setAfter] = useState('');
+  const [references, setReferences] = useState<string[]>([]);
+  const [newRef, setNewRef] = useState('');
+
+  useEffect(() => {
+    if (relationship) {
+      setBefore(relationship.before);
+      setAfter(relationship.after);
+      setReferences([...relationship.references]);
+    } else {
+      setBefore('');
+      setAfter('');
+      setReferences([]);
+    }
+    setNewRef('');
+  }, [relationship, open]);
+
+  const handleAddRef = () => {
+    const trimmed = newRef.trim();
+    if (trimmed && !references.includes(trimmed)) {
+      setReferences([...references, trimmed]);
+      setNewRef('');
+    }
+  };
+
+  const handleRemoveRef = (ref: string) => {
+    setReferences(references.filter((r) => r !== ref));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddRef();
+    }
+  };
+
+  const handleSave = () => {
+    if (!before.trim() || !after.trim()) return;
+    onSave(
+      { before: before.trim(), after: after.trim(), references },
+      relationship?.before,
+      relationship?.after
+    );
+    onClose();
+  };
+
+  const isValid = before.trim() && after.trim() && before.trim() !== after.trim();
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        {relationship ? 'Edit Relationship' : 'Add Relationship'}
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8 }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Autocomplete
+          freeSolo
+          options={signNames}
+          value={before}
+          onInputChange={(_, value) => setBefore(value)}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              autoFocus
+              margin="dense"
+              label="Before (this happens first)"
+              fullWidth
+            />
+          )}
+        />
+
+        <Autocomplete
+          freeSolo
+          options={signNames}
+          value={after}
+          onInputChange={(_, value) => setAfter(value)}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              margin="dense"
+              label="After (this happens second)"
+              fullWidth
+            />
+          )}
+        />
+
+        {before && after && before === after && (
+          <Typography color="error" variant="caption">
+            "Before" and "After" cannot be the same sign
+          </Typography>
+        )}
+
+        <Typography variant="subtitle2" sx={{ mt: 3 }}>
+          Scripture References ({references.length})
+        </Typography>
+
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', mt: 1, mb: 2 }}>
+          {references.length === 0 && (
+            <Typography variant="body2" color="textSecondary">
+              No references yet
+            </Typography>
+          )}
+          {references.map((ref) => (
+            <Chip
+              key={ref}
+              label={ref}
+              onDelete={() => handleRemoveRef(ref)}
+              sx={{ m: 0.5 }}
+              size="small"
+            />
+          ))}
+        </Box>
+
+        <TextField
+          sx={{ mt: 1 }}
+          margin="dense"
+          label="Add Reference"
+          placeholder="e.g., D&C 45:26-27"
+          fullWidth
+          value={newRef}
+          onChange={(e) => setNewRef(e.target.value)}
+          onKeyDown={handleKeyDown}
+          helperText="Press Enter to add"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSave}
+          color="primary"
+          variant="contained"
+          disabled={!isValid}
+        >
+          {relationship ? 'Update' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/lib/db/relationships.ts
+++ b/lib/db/relationships.ts
@@ -1,54 +1,118 @@
 import fs from 'fs';
-import relationships from '../../data/relationships.json';
+import path from 'path';
+import relationshipsData from '../../data/relationships.json';
 
 export type Relationship = {
   before: string;
   after: string;
   references: string[];
+};
+
+// Mutable copy
+const relationships: Relationship[] = [...relationshipsData];
+
+// Create composite key for indexing
+function makeKey(before: string, after: string): string {
+  return `${before}|||${after}`;
 }
 
-const index: Record<string, string[]> = {};
-relationships.forEach(addRelationshipToIndex)
-
-function getRelKey(rel: Relationship) {
-  return `${rel.before}::${rel.after}`;
-}
-
-function addRelationshipToIndex(relationship: Relationship) {
-  const key = getRelKey(relationship);
-  index[getRelKey(relationship)] = relationship.references;
-}
-
-function relKeyExists(key: string) {
-  return !!index[key];
-}
+const index: Record<string, Relationship> = {};
+relationships.forEach(rel => {
+  index[makeKey(rel.before, rel.after)] = rel;
+});
 
 export function getRelationships(): Relationship[] {
   return [...relationships];
 }
 
-export function addRelationship(relationship: Relationship) {
-  relationships.push(relationship);
-  addRelationshipToIndex(relationship);
+export function getRelationship(before: string, after: string): Relationship | undefined {
+  return index[makeKey(before, after)];
 }
 
-export function addReference(before: string, after: string, reference: string) {
-  const newRel = { before, after, references: [reference] };
-  const key = getRelKey(newRel);
+export function addRelationship(rel: Relationship): Relationship {
+  const key = makeKey(rel.before, rel.after);
   
-  // If the relationship already exists, update the references
-  if (relKeyExists(key)) {
-    if (!index[key].includes(reference)) {
-      index[key].push(reference);
+  if (!index[key]) {
+    relationships.push(rel);
+    index[key] = rel;
+  } else {
+    // Merge references if relationship exists
+    const existing = index[key];
+    const dedupedRefs = new Set([...existing.references, ...rel.references]);
+    existing.references = [...dedupedRefs];
+  }
+  
+  return index[key];
+}
+
+export function updateRelationship(
+  oldBefore: string,
+  oldAfter: string,
+  updated: Relationship
+): Relationship | null {
+  const oldKey = makeKey(oldBefore, oldAfter);
+  const existing = index[oldKey];
+  if (!existing) return null;
+
+  const idx = relationships.findIndex(
+    r => r.before === oldBefore && r.after === oldAfter
+  );
+  if (idx === -1) return null;
+
+  const newKey = makeKey(updated.before, updated.after);
+
+  // If key changed, check for conflicts
+  if (oldKey !== newKey) {
+    delete index[oldKey];
+    
+    if (index[newKey]) {
+      // Merge into existing
+      const target = index[newKey];
+      const dedupedRefs = new Set([...target.references, ...updated.references]);
+      target.references = [...dedupedRefs];
+      relationships.splice(idx, 1);
+      return target;
     }
   }
 
-  // Otherwise, create a new relationship
-  else {
-    addRelationship(newRel);
-  }
+  relationships[idx] = updated;
+  index[newKey] = updated;
+  return updated;
 }
 
-export function save() {
-  fs.writeFileSync('data/relationships.json', JSON.stringify(relationships, null, 2));
+export function deleteRelationship(before: string, after: string): boolean {
+  const key = makeKey(before, after);
+  const idx = relationships.findIndex(
+    r => r.before === before && r.after === after
+  );
+  
+  if (idx === -1) return false;
+
+  relationships.splice(idx, 1);
+  delete index[key];
+  return true;
+}
+
+export function saveRelationships() {
+  const filePath = path.join(process.cwd(), 'data/relationships.json');
+  fs.writeFileSync(filePath, JSON.stringify(relationships, null, 2));
+}
+
+// Alias for backward compatibility with import-signs
+export const save = saveRelationships;
+
+// Helper to add a single reference to a relationship
+export function addReference(before: string, after: string, reference: string) {
+  const key = makeKey(before, after);
+  
+  if (!index[key]) {
+    const rel: Relationship = { before, after, references: [reference] };
+    relationships.push(rel);
+    index[key] = rel;
+  } else {
+    const existing = index[key];
+    if (!existing.references.includes(reference)) {
+      existing.references.push(reference);
+    }
+  }
 }

--- a/pages/api/relationships/[...key].ts
+++ b/pages/api/relationships/[...key].ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  getRelationship,
+  updateRelationship,
+  deleteRelationship,
+  saveRelationships,
+  Relationship,
+} from '../../../lib/db/relationships';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { key } = req.query;
+
+  // key is [before, after] from URL like /api/relationships/Sign%20A/Sign%20B
+  if (!Array.isArray(key) || key.length !== 2) {
+    return res.status(400).json({ error: 'Invalid relationship key. Use /api/relationships/{before}/{after}' });
+  }
+
+  const [before, after] = key.map(decodeURIComponent);
+
+  if (req.method === 'GET') {
+    const rel = getRelationship(before, after);
+    if (!rel) {
+      return res.status(404).json({ error: 'Relationship not found' });
+    }
+    return res.status(200).json(rel);
+  }
+
+  if (req.method === 'PUT') {
+    const body = req.body as Partial<Relationship>;
+
+    if (!body.before || !body.after) {
+      return res.status(400).json({ error: '"before" and "after" are required' });
+    }
+
+    const updated: Relationship = {
+      before: body.before.trim(),
+      after: body.after.trim(),
+      references: Array.isArray(body.references) ? body.references : [],
+    };
+
+    const result = updateRelationship(before, after, updated);
+    if (!result) {
+      return res.status(404).json({ error: 'Relationship not found' });
+    }
+
+    saveRelationships();
+    return res.status(200).json(result);
+  }
+
+  if (req.method === 'DELETE') {
+    const deleted = deleteRelationship(before, after);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Relationship not found' });
+    }
+
+    saveRelationships();
+    return res.status(204).end();
+  }
+
+  res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+  return res.status(405).json({ error: `Method ${req.method} not allowed` });
+}

--- a/pages/api/relationships/index.ts
+++ b/pages/api/relationships/index.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import {
+  getRelationships,
+  addRelationship,
+  saveRelationships,
+  Relationship,
+} from '../../../lib/db/relationships';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json(getRelationships());
+  }
+
+  if (req.method === 'POST') {
+    const { before, after, references } = req.body;
+
+    if (!before || typeof before !== 'string') {
+      return res.status(400).json({ error: '"before" sign is required' });
+    }
+    if (!after || typeof after !== 'string') {
+      return res.status(400).json({ error: '"after" sign is required' });
+    }
+
+    const rel: Relationship = {
+      before: before.trim(),
+      after: after.trim(),
+      references: Array.isArray(references) ? references : [],
+    };
+
+    const result = addRelationship(rel);
+    saveRelationships();
+
+    return res.status(201).json(result);
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  return res.status(405).json({ error: `Method ${req.method} not allowed` });
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,7 +21,7 @@ const sections = [
     title: 'Relationships',
     description: 'Edit before/after relationships between signs',
     href: '/relationships',
-    ready: false,
+    ready: true,
   },
   {
     title: 'Synonyms',

--- a/pages/relationships.tsx
+++ b/pages/relationships.tsx
@@ -1,0 +1,232 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Container,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Button,
+  TextField,
+  Box,
+  Chip,
+  Tooltip,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import RelationshipDialog from '../components/RelationshipDialog';
+import DeleteDialog from '../components/DeleteDialog';
+
+type Relationship = {
+  before: string;
+  after: string;
+  references: string[];
+};
+
+type Sign = {
+  name: string;
+  references: string[];
+};
+
+export default function Relationships() {
+  const [relationships, setRelationships] = useState<Relationship[]>([]);
+  const [signs, setSigns] = useState<Sign[]>([]);
+  const [search, setSearch] = useState('');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [editing, setEditing] = useState<Relationship | null>(null);
+  const [deleting, setDeleting] = useState<Relationship | null>(null);
+
+  const fetchRelationships = async () => {
+    const res = await fetch('/api/relationships');
+    const data = await res.json();
+    setRelationships(data);
+  };
+
+  const fetchSigns = async () => {
+    const res = await fetch('/api/signs');
+    const data = await res.json();
+    setSigns(data);
+  };
+
+  useEffect(() => {
+    fetchRelationships();
+    fetchSigns();
+  }, []);
+
+  const signNames = signs.map((s) => s.name);
+
+  const filtered = relationships.filter(
+    (r) =>
+      r.before.toLowerCase().includes(search.toLowerCase()) ||
+      r.after.toLowerCase().includes(search.toLowerCase()) ||
+      r.references.some((ref) => ref.toLowerCase().includes(search.toLowerCase()))
+  );
+
+  const handleAdd = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (rel: Relationship) => {
+    setEditing(rel);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = (rel: Relationship) => {
+    setDeleting(rel);
+    setDeleteOpen(true);
+  };
+
+  const handleSave = async (
+    rel: Relationship,
+    originalBefore?: string,
+    originalAfter?: string
+  ) => {
+    if (originalBefore && originalAfter) {
+      // Update
+      await fetch(
+        `/api/relationships/${encodeURIComponent(originalBefore)}/${encodeURIComponent(
+          originalAfter
+        )}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(rel),
+        }
+      );
+    } else {
+      // Create
+      await fetch('/api/relationships', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(rel),
+      });
+    }
+    fetchRelationships();
+  };
+
+  const handleConfirmDelete = async () => {
+    if (deleting) {
+      await fetch(
+        `/api/relationships/${encodeURIComponent(deleting.before)}/${encodeURIComponent(
+          deleting.after
+        )}`,
+        { method: 'DELETE' }
+      );
+      setDeleteOpen(false);
+      setDeleting(null);
+      fetchRelationships();
+    }
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ pt: 3, pb: 3 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 2,
+        }}
+      >
+        <Typography variant="h4">
+          Relationships
+          <Box component="span" sx={{ color: 'text.secondary', ml: 1 }}>
+            ({filtered.length})
+          </Box>
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<AddIcon />}
+          onClick={handleAdd}
+        >
+          Add Relationship
+        </Button>
+      </Box>
+
+      <TextField
+        sx={{ mb: 2, width: 350 }}
+        variant="outlined"
+        size="small"
+        placeholder="Search signs or references..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Before</TableCell>
+              <TableCell sx={{ width: 50 }}></TableCell>
+              <TableCell>After</TableCell>
+              <TableCell>References</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map((rel) => (
+              <TableRow key={`${rel.before}|||${rel.after}`} hover>
+                <TableCell sx={{ fontWeight: 500 }}>{rel.before}</TableCell>
+                <TableCell>
+                  <ArrowForwardIcon fontSize="small" color="action" />
+                </TableCell>
+                <TableCell sx={{ fontWeight: 500 }}>{rel.after}</TableCell>
+                <TableCell sx={{ maxWidth: 300 }}>
+                  {rel.references.slice(0, 3).map((ref) => (
+                    <Tooltip key={ref} title={ref}>
+                      <Chip
+                        label={ref.length > 20 ? ref.slice(0, 20) + '...' : ref}
+                        size="small"
+                        sx={{ m: 0.25 }}
+                      />
+                    </Tooltip>
+                  ))}
+                  {rel.references.length > 3 && (
+                    <Chip
+                      label={`+${rel.references.length - 3} more`}
+                      size="small"
+                      sx={{ m: 0.25 }}
+                      variant="outlined"
+                    />
+                  )}
+                </TableCell>
+                <TableCell align="right">
+                  <IconButton size="small" onClick={() => handleEdit(rel)}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => handleDelete(rel)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <RelationshipDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSave={handleSave}
+        relationship={editing}
+        signNames={signNames}
+      />
+
+      <DeleteDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleConfirmDelete}
+        signName={deleting ? `${deleting.before} → ${deleting.after}` : ''}
+      />
+    </Container>
+  );
+}


### PR DESCRIPTION
## Features

- **API routes:**
  - `GET/POST /api/relationships` - list all, create new
  - `GET/PUT/DELETE /api/relationships/{before}/{after}` - read/update/delete by composite key

- **UI:**
  - Relationships page with table view (Before → After → References)
  - Search by sign name or reference
  - RelationshipDialog with autocomplete for existing sign names (or type new ones)
  - Reuses existing DeleteDialog

- Home page: Relationships now marked as ready ✓

Build passes ✓