### PR TITLE
Scaffold static export for public pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,18 +1,21 @@
 /** @type {import('next').NextConfig} */
+const isStaticExport = process.env.STATIC_EXPORT === '1';
+
 module.exports = {
-  output: 'export',
-  
-  // Exclude editor pages from static export
-  exportPathMap: async function (defaultPathMap) {
-    // Remove editor routes - they only work in dev mode
-    const paths = { ...defaultPathMap };
-    Object.keys(paths).forEach((path) => {
-      if (path.startsWith('/editor') || path.startsWith('/api')) {
-        delete paths[path];
-      }
-    });
-    return paths;
-  },
+  // Only set output: 'export' when building for static deployment
+  ...(isStaticExport && {
+    output: 'export',
+    exportPathMap: async function (defaultPathMap) {
+      // Remove editor routes - they only work in dev mode
+      const paths = { ...defaultPathMap };
+      Object.keys(paths).forEach((path) => {
+        if (path.startsWith('/editor') || path.startsWith('/api')) {
+          delete paths[path];
+        }
+      });
+      return paths;
+    },
+  }),
 
   webpack: (config, { isServer }) => {
     if (!isServer) {

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,23 @@
+/** @type {import('next').NextConfig} */
 module.exports = {
+  output: 'export',
+  
+  // Exclude editor pages from static export
+  exportPathMap: async function (defaultPathMap) {
+    // Remove editor routes - they only work in dev mode
+    const paths = { ...defaultPathMap };
+    Object.keys(paths).forEach((path) => {
+      if (path.startsWith('/editor') || path.startsWith('/api')) {
+        delete paths[path];
+      }
+    });
+    return paths;
+  },
+
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback.fs = false;
     }
     return config;
   },
-}
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "next build && next export",
+    "build:static": "STATIC_EXPORT=1 next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/pages/editor/groups.tsx
+++ b/pages/editor/groups.tsx
@@ -19,8 +19,8 @@ import {
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
-import GroupDialog from '../components/GroupDialog';
-import DeleteDialog from '../components/DeleteDialog';
+import GroupDialog from '../../components/GroupDialog';
+import DeleteDialog from '../../components/DeleteDialog';
 
 type Group = {
   name: string;

--- a/pages/editor/index.tsx
+++ b/pages/editor/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  Container,
+  Typography,
+  Card,
+  CardContent,
+  CardActionArea,
+  Grid,
+  Box,
+  Alert,
+} from '@mui/material';
+import Link from 'next/link';
+
+const sections = [
+  {
+    title: 'Signs',
+    description: 'View and manage the signs of the Second Coming',
+    href: '/editor/signs',
+  },
+  {
+    title: 'Relationships',
+    description: 'Edit before/after relationships between signs',
+    href: '/editor/relationships',
+  },
+  {
+    title: 'Synonyms',
+    description: 'Manage duplicate sign mappings',
+    href: '/editor/synonyms',
+  },
+  {
+    title: 'Groups',
+    description: 'Organize signs into logical clusters',
+    href: '/editor/groups',
+  },
+];
+
+export default function EditorHome() {
+  return (
+    <Container maxWidth="md" sx={{ pt: 4, pb: 4 }}>
+      <Typography variant="h3" sx={{ mb: 1 }}>
+        Editor
+      </Typography>
+      <Alert severity="info" sx={{ mb: 3 }}>
+        This editor is for local use only. It requires the Next.js dev server to be running.
+      </Alert>
+
+      <Grid container spacing={3}>
+        {sections.map((section) => (
+          <Grid item xs={12} sm={6} key={section.title}>
+            <Card sx={{ height: '100%' }} variant="outlined">
+              <Link href={section.href} passHref legacyBehavior>
+                <CardActionArea component="a">
+                  <CardContent>
+                    <Typography variant="h6" sx={{ fontWeight: 500 }}>
+                      {section.title}
+                    </Typography>
+                    <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
+                      {section.description}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Link>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+}

--- a/pages/editor/relationships.tsx
+++ b/pages/editor/relationships.tsx
@@ -20,8 +20,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import RelationshipDialog from '../components/RelationshipDialog';
-import DeleteDialog from '../components/DeleteDialog';
+import RelationshipDialog from '../../components/RelationshipDialog';
+import DeleteDialog from '../../components/DeleteDialog';
 
 type Relationship = {
   before: string;

--- a/pages/editor/signs.tsx
+++ b/pages/editor/signs.tsx
@@ -13,95 +13,85 @@ import {
   Button,
   TextField,
   Box,
+  Chip,
+  Tooltip,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import SynonymDialog from '../components/SynonymDialog';
-import DeleteDialog from '../components/DeleteDialog';
-
-type Synonym = {
-  duplicate: string;
-  synonym: string;
-};
+import SignDialog from '../../components/SignDialog';
+import DeleteDialog from '../../components/DeleteDialog';
 
 type Sign = {
   name: string;
   references: string[];
 };
 
-export default function Synonyms() {
-  const [synonyms, setSynonyms] = useState<Synonym[]>([]);
-  const [allSigns, setAllSigns] = useState<string[]>([]);
+export default function Signs() {
+  const [signs, setSigns] = useState<Sign[]>([]);
   const [search, setSearch] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [editingSynonym, setEditingSynonym] = useState<Synonym | null>(null);
-  const [deletingSynonym, setDeletingSynonym] = useState<Synonym | null>(null);
-
-  const fetchSynonyms = async () => {
-    const res = await fetch('/api/synonyms');
-    const data = await res.json();
-    setSynonyms(data);
-  };
+  const [editingSign, setEditingSign] = useState<Sign | null>(null);
+  const [deletingSign, setDeletingSign] = useState<Sign | null>(null);
 
   const fetchSigns = async () => {
     const res = await fetch('/api/signs');
-    const data: Sign[] = await res.json();
-    setAllSigns(data.map(s => s.name).sort());
+    const data = await res.json();
+    setSigns(data);
   };
 
   useEffect(() => {
-    fetchSynonyms();
     fetchSigns();
   }, []);
 
-  const filtered = synonyms.filter(s =>
-    s.duplicate.toLowerCase().includes(search.toLowerCase()) ||
-    s.synonym.toLowerCase().includes(search.toLowerCase())
+  const filtered = signs.filter(s =>
+    s.name.toLowerCase().includes(search.toLowerCase()) ||
+    s.references.some(r => r.toLowerCase().includes(search.toLowerCase()))
   );
 
   const handleAdd = () => {
-    setEditingSynonym(null);
+    setEditingSign(null);
     setDialogOpen(true);
   };
 
-  const handleEdit = (syn: Synonym) => {
-    setEditingSynonym(syn);
+  const handleEdit = (sign: Sign) => {
+    setEditingSign(sign);
     setDialogOpen(true);
   };
 
-  const handleDelete = (syn: Synonym) => {
-    setDeletingSynonym(syn);
+  const handleDelete = (sign: Sign) => {
+    setDeletingSign(sign);
     setDeleteOpen(true);
   };
 
-  const handleSave = async (syn: Synonym, originalDuplicate?: string) => {
-    if (originalDuplicate) {
-      await fetch(`/api/synonyms/${encodeURIComponent(originalDuplicate)}`, {
+  const handleSave = async (sign: Sign, originalName?: string) => {
+    if (originalName) {
+      // Update
+      await fetch(`/api/signs/${encodeURIComponent(originalName)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(syn),
+        body: JSON.stringify(sign),
       });
     } else {
-      await fetch('/api/synonyms', {
+      // Create
+      await fetch('/api/signs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(syn),
+        body: JSON.stringify(sign),
       });
     }
-    fetchSynonyms();
+    fetchSigns();
   };
 
   const handleConfirmDelete = async () => {
-    if (deletingSynonym) {
-      await fetch(`/api/synonyms/${encodeURIComponent(deletingSynonym.duplicate)}`, {
+    if (deletingSign) {
+      await fetch(`/api/signs/${encodeURIComponent(deletingSign.name)}`, {
         method: 'DELETE',
       });
       setDeleteOpen(false);
-      setDeletingSynonym(null);
-      fetchSynonyms();
+      setDeletingSign(null);
+      fetchSigns();
     }
   };
 
@@ -109,7 +99,7 @@ export default function Synonyms() {
     <Container maxWidth="lg" sx={{ pt: 3, pb: 3 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Typography variant="h4">
-          Synonyms
+          Signs
           <Box component="span" sx={{ color: 'text.secondary', ml: 1 }}>
             ({filtered.length})
           </Box>
@@ -120,19 +110,15 @@ export default function Synonyms() {
           startIcon={<AddIcon />}
           onClick={handleAdd}
         >
-          Add Synonym
+          Add Sign
         </Button>
       </Box>
-
-      <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
-        Synonyms map duplicate or alternate sign names to their canonical sign.
-      </Typography>
 
       <TextField
         sx={{ mb: 2, width: 300 }}
         variant="outlined"
         size="small"
-        placeholder="Search synonyms..."
+        placeholder="Search signs or references..."
         value={search}
         onChange={(e) => setSearch(e.target.value)}
       />
@@ -141,25 +127,39 @@ export default function Synonyms() {
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Duplicate Name</TableCell>
-              <TableCell></TableCell>
-              <TableCell>Canonical Sign</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>References</TableCell>
               <TableCell align="right">Actions</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
-            {filtered.map((syn) => (
-              <TableRow key={syn.duplicate} hover>
-                <TableCell sx={{ color: 'text.secondary' }}>{syn.duplicate}</TableCell>
-                <TableCell sx={{ width: 40 }}>
-                  <ArrowForwardIcon fontSize="small" color="action" />
+            {filtered.map((sign) => (
+              <TableRow key={sign.name} hover>
+                <TableCell sx={{ fontWeight: 500 }}>{sign.name}</TableCell>
+                <TableCell sx={{ maxWidth: 400 }}>
+                  {sign.references.slice(0, 5).map((ref) => (
+                    <Tooltip key={ref} title={ref}>
+                      <Chip
+                        label={ref.length > 25 ? ref.slice(0, 25) + '...' : ref}
+                        size="small"
+                        sx={{ m: 0.25, maxWidth: 200 }}
+                      />
+                    </Tooltip>
+                  ))}
+                  {sign.references.length > 5 && (
+                    <Chip
+                      label={`+${sign.references.length - 5} more`}
+                      size="small"
+                      sx={{ m: 0.25 }}
+                      variant="outlined"
+                    />
+                  )}
                 </TableCell>
-                <TableCell sx={{ fontWeight: 500 }}>{syn.synonym}</TableCell>
                 <TableCell align="right">
-                  <IconButton size="small" onClick={() => handleEdit(syn)}>
+                  <IconButton size="small" onClick={() => handleEdit(sign)}>
                     <EditIcon fontSize="small" />
                   </IconButton>
-                  <IconButton size="small" onClick={() => handleDelete(syn)}>
+                  <IconButton size="small" onClick={() => handleDelete(sign)}>
                     <DeleteIcon fontSize="small" />
                   </IconButton>
                 </TableCell>
@@ -169,19 +169,18 @@ export default function Synonyms() {
         </Table>
       </TableContainer>
 
-      <SynonymDialog
+      <SignDialog
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
         onSave={handleSave}
-        synonym={editingSynonym}
-        allSigns={allSigns}
+        sign={editingSign}
       />
 
       <DeleteDialog
         open={deleteOpen}
         onClose={() => setDeleteOpen(false)}
         onConfirm={handleConfirmDelete}
-        signName={deletingSynonym?.duplicate || ''}
+        signName={deletingSign?.name || ''}
       />
     </Container>
   );

--- a/pages/editor/synonyms.tsx
+++ b/pages/editor/synonyms.tsx
@@ -1,0 +1,188 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Container,
+  Typography,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Button,
+  TextField,
+  Box,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import SynonymDialog from '../../components/SynonymDialog';
+import DeleteDialog from '../../components/DeleteDialog';
+
+type Synonym = {
+  duplicate: string;
+  synonym: string;
+};
+
+type Sign = {
+  name: string;
+  references: string[];
+};
+
+export default function Synonyms() {
+  const [synonyms, setSynonyms] = useState<Synonym[]>([]);
+  const [allSigns, setAllSigns] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [editingSynonym, setEditingSynonym] = useState<Synonym | null>(null);
+  const [deletingSynonym, setDeletingSynonym] = useState<Synonym | null>(null);
+
+  const fetchSynonyms = async () => {
+    const res = await fetch('/api/synonyms');
+    const data = await res.json();
+    setSynonyms(data);
+  };
+
+  const fetchSigns = async () => {
+    const res = await fetch('/api/signs');
+    const data: Sign[] = await res.json();
+    setAllSigns(data.map(s => s.name).sort());
+  };
+
+  useEffect(() => {
+    fetchSynonyms();
+    fetchSigns();
+  }, []);
+
+  const filtered = synonyms.filter(s =>
+    s.duplicate.toLowerCase().includes(search.toLowerCase()) ||
+    s.synonym.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const handleAdd = () => {
+    setEditingSynonym(null);
+    setDialogOpen(true);
+  };
+
+  const handleEdit = (syn: Synonym) => {
+    setEditingSynonym(syn);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = (syn: Synonym) => {
+    setDeletingSynonym(syn);
+    setDeleteOpen(true);
+  };
+
+  const handleSave = async (syn: Synonym, originalDuplicate?: string) => {
+    if (originalDuplicate) {
+      await fetch(`/api/synonyms/${encodeURIComponent(originalDuplicate)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(syn),
+      });
+    } else {
+      await fetch('/api/synonyms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(syn),
+      });
+    }
+    fetchSynonyms();
+  };
+
+  const handleConfirmDelete = async () => {
+    if (deletingSynonym) {
+      await fetch(`/api/synonyms/${encodeURIComponent(deletingSynonym.duplicate)}`, {
+        method: 'DELETE',
+      });
+      setDeleteOpen(false);
+      setDeletingSynonym(null);
+      fetchSynonyms();
+    }
+  };
+
+  return (
+    <Container maxWidth="lg" sx={{ pt: 3, pb: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h4">
+          Synonyms
+          <Box component="span" sx={{ color: 'text.secondary', ml: 1 }}>
+            ({filtered.length})
+          </Box>
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<AddIcon />}
+          onClick={handleAdd}
+        >
+          Add Synonym
+        </Button>
+      </Box>
+
+      <Typography variant="body2" color="textSecondary" sx={{ mb: 2 }}>
+        Synonyms map duplicate or alternate sign names to their canonical sign.
+      </Typography>
+
+      <TextField
+        sx={{ mb: 2, width: 300 }}
+        variant="outlined"
+        size="small"
+        placeholder="Search synonyms..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Duplicate Name</TableCell>
+              <TableCell></TableCell>
+              <TableCell>Canonical Sign</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map((syn) => (
+              <TableRow key={syn.duplicate} hover>
+                <TableCell sx={{ color: 'text.secondary' }}>{syn.duplicate}</TableCell>
+                <TableCell sx={{ width: 40 }}>
+                  <ArrowForwardIcon fontSize="small" color="action" />
+                </TableCell>
+                <TableCell sx={{ fontWeight: 500 }}>{syn.synonym}</TableCell>
+                <TableCell align="right">
+                  <IconButton size="small" onClick={() => handleEdit(syn)}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton size="small" onClick={() => handleDelete(syn)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <SynonymDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        onSave={handleSave}
+        synonym={editingSynonym}
+        allSigns={allSigns}
+      />
+
+      <DeleteDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleConfirmDelete}
+        signName={deletingSynonym?.duplicate || ''}
+      />
+    </Container>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,86 +1,24 @@
 import React from 'react';
-import {
-  Container,
-  Typography,
-  Card,
-  CardContent,
-  CardActionArea,
-  Grid,
-  Box,
-} from '@mui/material';
+import { Container, Typography, Box, Button, Stack } from '@mui/material';
 import Link from 'next/link';
-
-const sections = [
-  {
-    title: 'Signs',
-    description: 'View and manage the signs of the Second Coming',
-    href: '/signs',
-    ready: true,
-  },
-  {
-    title: 'Relationships',
-    description: 'Edit before/after relationships between signs',
-    href: '/relationships',
-    ready: true,
-  },
-  {
-    title: 'Synonyms',
-    description: 'Manage duplicate sign mappings',
-    href: '/synonyms',
-    ready: true,
-  },
-  {
-    title: 'Groups',
-    description: 'Organize signs into logical clusters',
-    href: '/groups',
-    ready: true,
-  },
-];
 
 export default function Home() {
   return (
-    <Container maxWidth="md" sx={{ pt: 4, pb: 4 }}>
-      <Typography variant="h3" sx={{ mb: 1 }}>
+    <Container maxWidth="md" sx={{ pt: 8, pb: 8 }}>
+      <Typography variant="h2" sx={{ mb: 2, fontWeight: 600 }}>
         Signs of the Second Coming
       </Typography>
-      <Typography variant="body1" sx={{ mb: 4, color: 'text.secondary' }}>
-        Editor for managing signs, relationships, and scripture references
+      <Typography variant="h5" sx={{ mb: 4, color: 'text.secondary', fontWeight: 400 }}>
+        Exploring the order of prophetic signs leading to the return of Christ
       </Typography>
-
-      <Grid container spacing={3}>
-        {sections.map((section) => (
-          <Grid item xs={12} sm={6} key={section.title}>
-            <Card sx={{ height: '100%' }} variant="outlined">
-              {section.ready ? (
-                <Link href={section.href} passHref legacyBehavior>
-                  <CardActionArea component="a">
-                    <CardContent>
-                      <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                        {section.title}
-                      </Typography>
-                      <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
-                        {section.description}
-                      </Typography>
-                    </CardContent>
-                  </CardActionArea>
-                </Link>
-              ) : (
-                <CardContent sx={{ opacity: 0.5 }}>
-                  <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                    {section.title}
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: 'text.secondary', mt: 1 }}>
-                    {section.description}
-                  </Typography>
-                  <Typography variant="caption" color="textSecondary">
-                    Coming soon
-                  </Typography>
-                </CardContent>
-              )}
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
+      
+      <Stack direction="row" spacing={2}>
+        <Link href="/signs" passHref legacyBehavior>
+          <Button variant="contained" size="large">
+            View Signs
+          </Button>
+        </Link>
+      </Stack>
     </Container>
   );
 }

--- a/pages/signs.tsx
+++ b/pages/signs.tsx
@@ -1,187 +1,67 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   Container,
   Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  IconButton,
-  Button,
-  TextField,
-  Box,
+  Card,
+  CardContent,
+  List,
+  ListItem,
+  ListItemText,
   Chip,
-  Tooltip,
+  Box,
+  Stack,
 } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import AddIcon from '@mui/icons-material/Add';
-import SignDialog from '../components/SignDialog';
-import DeleteDialog from '../components/DeleteDialog';
+import { GetStaticProps } from 'next';
+import signsData from '../data/signs.json';
 
-type Sign = {
+interface Sign {
   name: string;
   references: string[];
+}
+
+interface Props {
+  signs: Sign[];
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  return {
+    props: {
+      signs: signsData as Sign[],
+    },
+  };
 };
 
-export default function Signs() {
-  const [signs, setSigns] = useState<Sign[]>([]);
-  const [search, setSearch] = useState('');
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [editingSign, setEditingSign] = useState<Sign | null>(null);
-  const [deletingSign, setDeletingSign] = useState<Sign | null>(null);
-
-  const fetchSigns = async () => {
-    const res = await fetch('/api/signs');
-    const data = await res.json();
-    setSigns(data);
-  };
-
-  useEffect(() => {
-    fetchSigns();
-  }, []);
-
-  const filtered = signs.filter(s =>
-    s.name.toLowerCase().includes(search.toLowerCase()) ||
-    s.references.some(r => r.toLowerCase().includes(search.toLowerCase()))
-  );
-
-  const handleAdd = () => {
-    setEditingSign(null);
-    setDialogOpen(true);
-  };
-
-  const handleEdit = (sign: Sign) => {
-    setEditingSign(sign);
-    setDialogOpen(true);
-  };
-
-  const handleDelete = (sign: Sign) => {
-    setDeletingSign(sign);
-    setDeleteOpen(true);
-  };
-
-  const handleSave = async (sign: Sign, originalName?: string) => {
-    if (originalName) {
-      // Update
-      await fetch(`/api/signs/${encodeURIComponent(originalName)}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(sign),
-      });
-    } else {
-      // Create
-      await fetch('/api/signs', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(sign),
-      });
-    }
-    fetchSigns();
-  };
-
-  const handleConfirmDelete = async () => {
-    if (deletingSign) {
-      await fetch(`/api/signs/${encodeURIComponent(deletingSign.name)}`, {
-        method: 'DELETE',
-      });
-      setDeleteOpen(false);
-      setDeletingSign(null);
-      fetchSigns();
-    }
-  };
-
+export default function SignsPage({ signs }: Props) {
   return (
-    <Container maxWidth="lg" sx={{ pt: 3, pb: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Typography variant="h4">
-          Signs
-          <Box component="span" sx={{ color: 'text.secondary', ml: 1 }}>
-            ({filtered.length})
-          </Box>
-        </Typography>
-        <Button
-          variant="contained"
-          color="primary"
-          startIcon={<AddIcon />}
-          onClick={handleAdd}
-        >
-          Add Sign
-        </Button>
-      </Box>
+    <Container maxWidth="md" sx={{ pt: 4, pb: 4 }}>
+      <Typography variant="h3" sx={{ mb: 1 }}>
+        Signs
+      </Typography>
+      <Typography variant="body1" sx={{ mb: 4, color: 'text.secondary' }}>
+        {signs.length} signs with scripture references
+      </Typography>
 
-      <TextField
-        sx={{ mb: 2, width: 300 }}
-        variant="outlined"
-        size="small"
-        placeholder="Search signs or references..."
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-      />
-
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>References</TableCell>
-              <TableCell align="right">Actions</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filtered.map((sign) => (
-              <TableRow key={sign.name} hover>
-                <TableCell sx={{ fontWeight: 500 }}>{sign.name}</TableCell>
-                <TableCell sx={{ maxWidth: 400 }}>
-                  {sign.references.slice(0, 5).map((ref) => (
-                    <Tooltip key={ref} title={ref}>
-                      <Chip
-                        label={ref.length > 25 ? ref.slice(0, 25) + '...' : ref}
-                        size="small"
-                        sx={{ m: 0.25, maxWidth: 200 }}
-                      />
-                    </Tooltip>
-                  ))}
-                  {sign.references.length > 5 && (
-                    <Chip
-                      label={`+${sign.references.length - 5} more`}
-                      size="small"
-                      sx={{ m: 0.25 }}
-                      variant="outlined"
-                    />
-                  )}
-                </TableCell>
-                <TableCell align="right">
-                  <IconButton size="small" onClick={() => handleEdit(sign)}>
-                    <EditIcon fontSize="small" />
-                  </IconButton>
-                  <IconButton size="small" onClick={() => handleDelete(sign)}>
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-
-      <SignDialog
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-        onSave={handleSave}
-        sign={editingSign}
-      />
-
-      <DeleteDialog
-        open={deleteOpen}
-        onClose={() => setDeleteOpen(false)}
-        onConfirm={handleConfirmDelete}
-        signName={deletingSign?.name || ''}
-      />
+      <Stack spacing={2}>
+        {signs.map((sign) => (
+          <Card key={sign.name} variant="outlined">
+            <CardContent>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                {sign.name}
+              </Typography>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                {sign.references.map((ref, i) => (
+                  <Chip
+                    key={i}
+                    label={ref}
+                    size="small"
+                    variant="outlined"
+                  />
+                ))}
+              </Box>
+            </CardContent>
+          </Card>
+        ))}
+      </Stack>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
Separates the editor (local dev only) from public pages that can be statically exported.

## Changes
- Move editor pages to `/editor/*` route
- Create public index and signs pages using `getStaticProps`
- Configure `next.config.js` with `output: 'export'`
- Exclude `/editor` and `/api` routes from static build via `exportPathMap`

## Usage

**Dev mode** (editor works):
```bash
npm run dev
# Visit http://localhost:3000/editor
```

**Static build** (public pages only):
```bash
npm run build
npx serve out
```

## Output
- `/out/index.html` — public home page
- `/out/signs.html` — signs list with data baked in
- Editor pages excluded from static output