### PR TITLE
Add graph visualization with Graphviz

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "build:static": "STATIC_EXPORT=1 next build",
+    "generate-graph": "node scripts/generate-graph.js",
+    "build:static": "npm run generate-graph && STATIC_EXPORT=1 next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,38 +1,117 @@
-import React from 'react';
-import { Container, Typography, Box, Button, Stack, Paper } from '@mui/material';
+import React, { useState, useRef, useCallback } from 'react';
+import { Box, IconButton, Paper, Typography, ButtonGroup, Tooltip } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import Link from 'next/link';
 
-export default function Home() {
-  return (
-    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <Container maxWidth="lg" sx={{ pt: 4, pb: 2 }}>
-        <Typography variant="h3" sx={{ mb: 1, fontWeight: 600 }}>
-          Signs of the Second Coming
-        </Typography>
-        <Typography variant="body1" sx={{ mb: 3, color: 'text.secondary' }}>
-          Exploring the order of prophetic signs leading to the return of Christ
-        </Typography>
-        
-        <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
-          <Link href="/signs" passHref legacyBehavior>
-            <Button variant="outlined" size="small">
-              View Signs List
-            </Button>
-          </Link>
-        </Stack>
-      </Container>
+const MIN_ZOOM = 0.1;
+const MAX_ZOOM = 3;
+const ZOOM_STEP = 0.2;
 
-      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', px: 2, pb: 2 }}>
-        <Paper 
-          variant="outlined" 
-          sx={{ 
-            flex: 1,
-            overflow: 'auto',
-            display: 'flex',
-            alignItems: 'flex-start',
-            justifyContent: 'center',
-            backgroundColor: '#fafafa',
-            minHeight: 500,
+export default function Home() {
+  const [zoom, setZoom] = useState(0.5);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleZoomIn = useCallback(() => {
+    setZoom((z) => Math.min(MAX_ZOOM, z + ZOOM_STEP));
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    setZoom((z) => Math.max(MIN_ZOOM, z - ZOOM_STEP));
+  }, []);
+
+  const handleZoomReset = useCallback(() => {
+    setZoom(0.5);
+  }, []);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
+      setZoom((z) => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z + delta)));
+    }
+  }, []);
+
+  return (
+    <Box 
+      sx={{ 
+        height: '100vh', 
+        width: '100vw',
+        display: 'flex', 
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <Box 
+        sx={{ 
+          px: 2, 
+          py: 1, 
+          borderBottom: 1, 
+          borderColor: 'divider',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          backgroundColor: 'background.paper',
+        }}
+      >
+        <Box>
+          <Typography variant="h6" component="h1" sx={{ fontWeight: 600 }}>
+            Signs of the Second Coming
+          </Typography>
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            <Link href="/signs" style={{ color: 'inherit' }}>View signs list</Link>
+            {' · '}
+            Scroll to pan, Ctrl+scroll to zoom
+          </Typography>
+        </Box>
+
+        {/* Zoom controls */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" sx={{ color: 'text.secondary', minWidth: 50, textAlign: 'right' }}>
+            {Math.round(zoom * 100)}%
+          </Typography>
+          <ButtonGroup size="small" variant="outlined">
+            <Tooltip title="Zoom out">
+              <IconButton onClick={handleZoomOut} disabled={zoom <= MIN_ZOOM} size="small">
+                <RemoveIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Reset zoom">
+              <IconButton onClick={handleZoomReset} size="small">
+                <RestartAltIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Zoom in">
+              <IconButton onClick={handleZoomIn} disabled={zoom >= MAX_ZOOM} size="small">
+                <AddIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </ButtonGroup>
+        </Box>
+      </Box>
+
+      {/* Graph container */}
+      <Box 
+        ref={containerRef}
+        onWheel={handleWheel}
+        sx={{ 
+          flex: 1,
+          overflow: 'auto',
+          backgroundColor: '#f5f5f5',
+          cursor: 'grab',
+          '&:active': {
+            cursor: 'grabbing',
+          },
+        }}
+      >
+        <Box
+          sx={{
+            transformOrigin: '0 0',
+            transform: `scale(${zoom})`,
+            transition: 'transform 0.1s ease-out',
+            padding: 2,
           }}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -40,15 +119,12 @@ export default function Home() {
             src="/graph.svg" 
             alt="Graph of signs and their relationships"
             style={{ 
+              display: 'block',
               maxWidth: 'none',
-              height: 'auto',
-              padding: '16px',
             }}
+            draggable={false}
           />
-        </Paper>
-        <Typography variant="caption" sx={{ mt: 1, color: 'text.secondary', textAlign: 'center' }}>
-          Scroll to explore the graph. Each box is a sign; arrows show &quot;before → after&quot; relationships.
-        </Typography>
+        </Box>
       </Box>
     </Box>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,24 +1,55 @@
 import React from 'react';
-import { Container, Typography, Box, Button, Stack } from '@mui/material';
+import { Container, Typography, Box, Button, Stack, Paper } from '@mui/material';
 import Link from 'next/link';
 
 export default function Home() {
   return (
-    <Container maxWidth="md" sx={{ pt: 8, pb: 8 }}>
-      <Typography variant="h2" sx={{ mb: 2, fontWeight: 600 }}>
-        Signs of the Second Coming
-      </Typography>
-      <Typography variant="h5" sx={{ mb: 4, color: 'text.secondary', fontWeight: 400 }}>
-        Exploring the order of prophetic signs leading to the return of Christ
-      </Typography>
-      
-      <Stack direction="row" spacing={2}>
-        <Link href="/signs" passHref legacyBehavior>
-          <Button variant="contained" size="large">
-            View Signs
-          </Button>
-        </Link>
-      </Stack>
-    </Container>
+    <Box sx={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <Container maxWidth="lg" sx={{ pt: 4, pb: 2 }}>
+        <Typography variant="h3" sx={{ mb: 1, fontWeight: 600 }}>
+          Signs of the Second Coming
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 3, color: 'text.secondary' }}>
+          Exploring the order of prophetic signs leading to the return of Christ
+        </Typography>
+        
+        <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
+          <Link href="/signs" passHref legacyBehavior>
+            <Button variant="outlined" size="small">
+              View Signs List
+            </Button>
+          </Link>
+        </Stack>
+      </Container>
+
+      <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', px: 2, pb: 2 }}>
+        <Paper 
+          variant="outlined" 
+          sx={{ 
+            flex: 1,
+            overflow: 'auto',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'center',
+            backgroundColor: '#fafafa',
+            minHeight: 500,
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img 
+            src="/graph.svg" 
+            alt="Graph of signs and their relationships"
+            style={{ 
+              maxWidth: 'none',
+              height: 'auto',
+              padding: '16px',
+            }}
+          />
+        </Paper>
+        <Typography variant="caption" sx={{ mt: 1, color: 'text.secondary', textAlign: 'center' }}>
+          Scroll to explore the graph. Each box is a sign; arrows show &quot;before → after&quot; relationships.
+        </Typography>
+      </Box>
+    </Box>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useRef, useCallback } from 'react';
-import { Box, IconButton, Paper, Typography, ButtonGroup, Tooltip } from '@mui/material';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { Box, IconButton, Typography, ButtonGroup, Tooltip } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
@@ -11,6 +11,9 @@ const ZOOM_STEP = 0.2;
 
 export default function Home() {
   const [zoom, setZoom] = useState(0.5);
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+  const [scrollStart, setScrollStart] = useState({ x: 0, y: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleZoomIn = useCallback(() => {
@@ -32,6 +35,51 @@ export default function Home() {
       setZoom((z) => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, z + delta)));
     }
   }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // Only left mouse button
+    if (e.button !== 0) return;
+    
+    const container = containerRef.current;
+    if (!container) return;
+
+    setIsDragging(true);
+    setDragStart({ x: e.clientX, y: e.clientY });
+    setScrollStart({ x: container.scrollLeft, y: container.scrollTop });
+  }, []);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging) return;
+    
+    const container = containerRef.current;
+    if (!container) return;
+
+    const deltaX = e.clientX - dragStart.x;
+    const deltaY = e.clientY - dragStart.y;
+
+    container.scrollLeft = scrollStart.x - deltaX;
+    container.scrollTop = scrollStart.y - deltaY;
+  }, [isDragging, dragStart, scrollStart]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Prevent text selection while dragging
+  useEffect(() => {
+    if (isDragging) {
+      document.body.style.userSelect = 'none';
+    } else {
+      document.body.style.userSelect = '';
+    }
+    return () => {
+      document.body.style.userSelect = '';
+    };
+  }, [isDragging]);
 
   return (
     <Box 
@@ -63,7 +111,7 @@ export default function Home() {
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
             <Link href="/signs" style={{ color: 'inherit' }}>View signs list</Link>
             {' · '}
-            Scroll to pan, Ctrl+scroll to zoom
+            Drag to pan, Ctrl+scroll to zoom
           </Typography>
         </Box>
 
@@ -96,21 +144,22 @@ export default function Home() {
       <Box 
         ref={containerRef}
         onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
         sx={{ 
           flex: 1,
           overflow: 'auto',
           backgroundColor: '#f5f5f5',
-          cursor: 'grab',
-          '&:active': {
-            cursor: 'grabbing',
-          },
+          cursor: isDragging ? 'grabbing' : 'grab',
         }}
       >
         <Box
           sx={{
             transformOrigin: '0 0',
             transform: `scale(${zoom})`,
-            transition: 'transform 0.1s ease-out',
+            transition: isDragging ? 'none' : 'transform 0.1s ease-out',
             padding: 2,
           }}
         >

--- a/scripts/generate-graph.js
+++ b/scripts/generate-graph.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Generate a Graphviz DOT file and SVG from signs and relationships data.
+ * 
+ * Usage: node scripts/generate-graph.js
+ * Output: public/graph.svg
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Load data
+const dataDir = path.join(__dirname, '..', 'data');
+const signs = JSON.parse(fs.readFileSync(path.join(dataDir, 'signs.json'), 'utf8'));
+const relationships = JSON.parse(fs.readFileSync(path.join(dataDir, 'relationships.json'), 'utf8'));
+const synonyms = JSON.parse(fs.readFileSync(path.join(dataDir, 'synonyms.json'), 'utf8'));
+
+// Build synonym map: duplicate -> canonical name
+const synonymMap = new Map();
+for (const { duplicate, synonym } of synonyms) {
+  synonymMap.set(duplicate, synonym);
+}
+
+// Resolve a sign name to its canonical form (following synonym chains)
+function resolve(name) {
+  const visited = new Set();
+  while (synonymMap.has(name) && !visited.has(name)) {
+    visited.add(name);
+    name = synonymMap.get(name);
+  }
+  return name;
+}
+
+// Get all unique canonical sign names
+const canonicalSigns = new Set();
+for (const sign of signs) {
+  canonicalSigns.add(resolve(sign.name));
+}
+
+// Build edges with resolved names, deduplicating
+const edges = new Map();
+for (const rel of relationships) {
+  const before = resolve(rel.before);
+  const after = resolve(rel.after);
+  
+  // Skip self-loops
+  if (before === after) continue;
+  
+  const key = `${before}|||${after}`;
+  if (!edges.has(key)) {
+    edges.set(key, { before, after, references: [] });
+  }
+  edges.get(key).references.push(...rel.references);
+}
+
+// Escape label for DOT format
+function escapeLabel(str) {
+  return str.replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+// Generate DOT file
+let dot = `digraph signs_of_the_second_coming {
+  rankdir=TB;
+  node [shape=box, style="rounded,filled", fillcolor="#f0f0f0", fontname="Arial"];
+  edge [fontname="Arial", fontsize=10];
+  
+`;
+
+// Add nodes
+for (const name of canonicalSigns) {
+  dot += `  "${escapeLabel(name)}";\n`;
+}
+
+dot += '\n';
+
+// Add edges
+for (const { before, after } of edges.values()) {
+  dot += `  "${escapeLabel(before)}" -> "${escapeLabel(after)}";\n`;
+}
+
+dot += '}\n';
+
+// Write DOT file
+const publicDir = path.join(__dirname, '..', 'public');
+if (!fs.existsSync(publicDir)) {
+  fs.mkdirSync(publicDir, { recursive: true });
+}
+
+const dotPath = path.join(publicDir, 'graph.dot');
+const svgPath = path.join(publicDir, 'graph.svg');
+
+fs.writeFileSync(dotPath, dot);
+console.log(`Generated: ${dotPath}`);
+
+// Generate SVG using Graphviz
+try {
+  execSync(`dot -Tsvg "${dotPath}" -o "${svgPath}"`, { stdio: 'inherit' });
+  console.log(`Generated: ${svgPath}`);
+} catch (error) {
+  console.error('Failed to generate SVG. Is Graphviz installed?');
+  console.error('Install with: sudo apt-get install graphviz');
+  process.exit(1);
+}
+
+// Stats
+console.log(`\nStats:`);
+console.log(`  Signs: ${canonicalSigns.size}`);
+console.log(`  Relationships: ${edges.size}`);
+console.log(`  Synonyms applied: ${synonyms.length}`);


### PR DESCRIPTION
## Summary
Generates an SVG graph from the signs and relationships data using Graphviz, displayed on the homepage.

## Changes
- **scripts/generate-graph.js** — Reads signs, relationships, and synonyms JSON; applies synonym mappings to consolidate duplicates; outputs DOT and SVG
- **pages/index.tsx** — Displays the SVG in a scrollable container
- **package.json** — Added `generate-graph` script; `build:static` now runs it first

## How it works
1. Signs become nodes in the graph
2. Relationships become directed edges (before → after)  
3. Synonyms are resolved so duplicates merge into canonical names
4. Graphviz `dot` renders the layout as SVG

## Stats
- 145 canonical signs
- 238 relationships
- 33 synonyms applied

## Requirements
Graphviz must be installed: `sudo apt-get install graphviz` (or `brew install graphviz` on Mac)

## Test
```bash
npm run build:static
npx serve out
```