### PR TITLE
Add simplified graph with groups collapsed

### DIFF
--- a/data/graph-data-simple.json
+++ b/data/graph-data-simple.json
@@ -1,0 +1,2380 @@
+{
+  "Restoration": {
+    "name": "Restoration",
+    "references": [
+      "Isaiah 10:20-21",
+      "Revelation 7:2, D&C 77:9",
+      "2 Nephi 30:8,10",
+      "D&C 29:7",
+      "D&C 33:6",
+      "D&C 39:11",
+      "D&C 45:28-30",
+      "D&C 63:54",
+      "D&C 77:15",
+      "D&C 88:87-93",
+      "D&C 116",
+      "D&C 133:7-8",
+      "Assumption",
+      "Isaiah 49:22-23",
+      "1 Nephi 21:22-23",
+      "2 Nephi 6-7",
+      "Malachi 4:5",
+      "Romans 11:25-26",
+      "1 Nephi 15:13",
+      "3 Nephi 16:4-5",
+      "Revelation 7:3-4",
+      "1 Nephi 22:6",
+      "1 Nephi 22:8"
+    ],
+    "aliases": [
+      "Standard is setup",
+      "Fulness of the Gentiles",
+      "Lord lifts his hand upon the Gentiles",
+      "Marvelous work among the Gentiles"
+    ],
+    "members": [
+      "Elijah appears",
+      "Elias"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Remnant shall return to God",
+        "references": [
+          "Isaiah 10:20-21"
+        ]
+      },
+      {
+        "sign": "Gathering of Israel",
+        "references": [
+          "Isaiah 49:22-23",
+          "1 Nephi 21:22-23",
+          "2 Nephi 6-7",
+          "Romans 11:25-26",
+          "1 Nephi 22:6",
+          "3 Nephi 16:4-5"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "Malachi 4:5"
+        ]
+      },
+      {
+        "sign": "Sealing of the 144,000",
+        "references": [
+          "Revelation 7:3-4"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "1 Nephi 15:13",
+          "D&C 39:11",
+          "D&C 88:87-93",
+          "D&C 133:7-8",
+          "Assumption"
+        ]
+      },
+      {
+        "sign": "Wheat and Tares",
+        "references": [
+          "2 Nephi 30:8,10",
+          "D&C 63:54"
+        ]
+      },
+      {
+        "sign": "Gathering of the elect",
+        "references": [
+          "D&C 29:7",
+          "D&C 33:6"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "D&C 45:28-30"
+        ]
+      },
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "D&C 77:15"
+        ]
+      },
+      {
+        "sign": "Gathering at Adam-Ondi-Ahman",
+        "references": [
+          "D&C 116"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 7:2, D&C 77:9"
+        ]
+      },
+      {
+        "sign": "Pre-Restoration",
+        "references": [
+          "1 Nephi 22:6",
+          "1 Nephi 22:8",
+          "3 Nephi 16:4-5"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles begins",
+        "references": [
+          "D&C 45:28-30"
+        ]
+      }
+    ]
+  },
+  "Remnant shall return to God": {
+    "name": "Remnant shall return to God",
+    "references": [
+      "Isaiah 10:20-21"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "Isaiah 10:20-21"
+        ]
+      }
+    ]
+  },
+  "Gathering of Israel": {
+    "name": "Gathering of Israel",
+    "references": [
+      "Isaiah 49:22-23",
+      "1 Nephi 21:22-23",
+      "1 Nephi 22:6",
+      "2 Nephi 6-7",
+      "Jeremiah 23:3",
+      "Romans 11:25-26",
+      "3 Nephi 16:4-5",
+      "3 Nephi 16:10-12",
+      "D&C 39:11"
+    ],
+    "aliases": [
+      "Gentiles are Nursing Parents",
+      "Remnant gathered out of all countries",
+      "All Israel is saved",
+      "Fulness of the gospel brought to the house of Israel",
+      "Recover the house of Israel"
+    ],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "Isaiah 49:22-23",
+          "1 Nephi 21:22-23",
+          "2 Nephi 6-7",
+          "Romans 11:25-26",
+          "1 Nephi 22:6",
+          "3 Nephi 16:4-5"
+        ]
+      },
+      {
+        "sign": "Pre-Restoration",
+        "references": [
+          "Jeremiah 23:3"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "3 Nephi 16:10-12"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "D&C 39:11"
+        ]
+      }
+    ]
+  },
+  "Millenium": {
+    "name": "Millenium",
+    "references": [
+      "Jeremiah 3:17-18",
+      "Jeremiah 23:5",
+      "Zechariah 14",
+      "D&C 76:63",
+      "2 Nephi 30:15-18",
+      "D&C 45:54",
+      "Assumption",
+      "D&C 88:99",
+      "D&C 88:100",
+      "D&C 88:102",
+      "D&C 88:103-104",
+      "D&C 88:105",
+      "D&C 88:106",
+      "D&C 88:107",
+      "D&C 88:108-110",
+      "D&C 88:110",
+      "D&C 88:111-115",
+      "D&C 101:23-25",
+      "D&C 133:25",
+      "D&C 133:26"
+    ],
+    "aliases": [],
+    "members": [
+      "Christ reigns as King",
+      "All things revealed",
+      "Heathen nations redeemed",
+      "Second trump: Redemption of Terrestrial spirits",
+      "Satan bound for 1000 years",
+      "Third trump: Redemption of Telestial spirits",
+      "Fourth trump: Sons of perdition",
+      "Fifth trump: Angel committeth the everlasting gospel",
+      "Every ear hear; every knee bow; every tongue confess",
+      "Sixth trump: she is fallen",
+      "Seventh trump: It is finished",
+      "Angels crowned with glory",
+      "Saints receive their inheritance",
+      "Satan loosed for a little season",
+      "Satan gathers his armies",
+      "Michael gathers his armies",
+      "Satan is defeated and cast away",
+      "All things become new"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Israel returns from the north",
+        "references": [
+          "Jeremiah 3:17-18",
+          "D&C 133:26"
+        ]
+      },
+      {
+        "sign": "Israel brought out of the north, and all countries",
+        "references": [
+          "Jeremiah 23:5"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Mount of Olives splits",
+        "references": [
+          "Zechariah 14"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "2 Nephi 30:15-18",
+          "D&C 45:54",
+          "D&C 76:63",
+          "D&C 88:99",
+          "D&C 101:23-25",
+          "Assumption"
+        ]
+      },
+      {
+        "sign": "Islands become one land",
+        "references": [
+          "D&C 133:25"
+        ]
+      }
+    ]
+  },
+  "Israel returns from the north": {
+    "name": "Israel returns from the north",
+    "references": [
+      "Jeremiah 3:17-18",
+      "D&C 133:26",
+      "D&C 133:27",
+      "D&C 133:30",
+      "D&C 133:32"
+    ],
+    "aliases": [],
+    "members": [
+      "Judah and Israel come together out of the land of the north",
+      "Those in the north countries shall come in remembrance before the Lord",
+      "A highway shall be cast up in the ocean",
+      "Those in the north countries shall bring their rich treasures to Ephraim",
+      "Those in the north countries shall be crowned with glory by Ephraim",
+      "Israel brough out of the north, and all countries"
+    ],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Millenium",
+        "references": [
+          "Jeremiah 3:17-18",
+          "D&C 133:26"
+        ]
+      }
+    ]
+  },
+  "Pre-Restoration": {
+    "name": "Pre-Restoration",
+    "references": [
+      "Jeremiah 23:3",
+      "Jeremiah 29:14",
+      "D&C 45:24-25",
+      "Assumption",
+      "1 Nephi 22:3",
+      "1 Nephi 22:4",
+      "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8",
+      "1 Nephi 13:12",
+      "1 Nephi 13:14",
+      "1 Nephi 15:17",
+      "1 Nephi 22:7",
+      "1 Nephi 22:8",
+      "1 Nephi 22:6",
+      "2 Nephi 10:6-8",
+      "3 Nephi 16:4-5"
+    ],
+    "aliases": [],
+    "members": [
+      "Scattering of Israel",
+      "Lehi's family in America",
+      "Destruction of the Nephites",
+      "Discovering of America",
+      "Columbus",
+      "Scattering of Lehi's seed",
+      "Mighty nation raised up"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Gathering of Israel",
+        "references": [
+          "Jeremiah 23:3"
+        ]
+      },
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "Jeremiah 29:14",
+          "D&C 45:24-25"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "1 Nephi 15:17"
+        ]
+      },
+      {
+        "sign": "Restoration",
+        "references": [
+          "1 Nephi 22:6",
+          "1 Nephi 22:8",
+          "3 Nephi 16:4-5"
+        ]
+      },
+      {
+        "sign": "Jews believe in Christ",
+        "references": [
+          "2 Nephi 10:6-8"
+        ]
+      },
+      {
+        "sign": "New Jerusalem",
+        "references": [
+          "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+        ]
+      }
+    ],
+    "comesAfter": []
+  },
+  "Israel brought out of the north, and all countries": {
+    "name": "Israel brought out of the north, and all countries",
+    "references": [
+      "Jeremiah 23:5"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Millenium",
+        "references": [
+          "Jeremiah 23:5"
+        ]
+      }
+    ]
+  },
+  "Jews gathered in Jerusalem": {
+    "name": "Jews gathered in Jerusalem",
+    "references": [
+      "Jeremiah 29:14",
+      "D&C 45:24-25",
+      "D&C 45:40-43",
+      "D&C 77:15",
+      "Teachings of the Prophet Joseph Smith; p286-287",
+      "Assumption"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "D&C 45:24-25"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 45:40-43"
+        ]
+      },
+      {
+        "sign": "Two witnesses prophecy, die, resurrected",
+        "references": [
+          "D&C 77:15"
+        ]
+      },
+      {
+        "sign": "Temple in Jerusalem rebuilt",
+        "references": [
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      },
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Assumption"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Pre-Restoration",
+        "references": [
+          "Jeremiah 29:14",
+          "D&C 45:24-25"
+        ]
+      },
+      {
+        "sign": "Restoration",
+        "references": [
+          "D&C 77:15"
+        ]
+      }
+    ]
+  },
+  "All nations gathered against Israel": {
+    "name": "All nations gathered against Israel",
+    "references": [
+      "Ezekiel 38:18-23",
+      "Ezekiel 39",
+      "Zechariah 14",
+      "Zechariah 14:12",
+      "Revelation 11:2",
+      "Revelation 16:12-16",
+      "Revelation 16:16-21",
+      "Assumption",
+      "Joel 3:14-16",
+      "JST Matt 1:18,22",
+      "JST Matt 1:23",
+      "JST Matt 1:33",
+      "Mark 13:24"
+    ],
+    "aliases": [
+      "Multitudes gathered in the valley of decision",
+      "Great tribulation of the Jews"
+    ],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "Ezekiel 38:18-23",
+          "JST Matt 1:33",
+          "Mark 13:24"
+        ]
+      },
+      {
+        "sign": "Great earthquake in Israel",
+        "references": [
+          "Ezekiel 38:18-23"
+        ]
+      },
+      {
+        "sign": "Gog and Magog defeated",
+        "references": [
+          "Ezekiel 39"
+        ]
+      },
+      {
+        "sign": "Darkness",
+        "references": [
+          "Joel 3:14-16",
+          "JST Matt 1:33",
+          "Mark 13:24"
+        ]
+      },
+      {
+        "sign": "Half of the city is captive",
+        "references": [
+          "Zechariah 14"
+        ]
+      },
+      {
+        "sign": "Flesh fall off their bones and eyes fall out",
+        "references": [
+          "Zechariah 14:12"
+        ]
+      },
+      {
+        "sign": "False Christs and false prophets",
+        "references": [
+          "JST Matt 1:18,22"
+        ]
+      },
+      {
+        "sign": "Wars",
+        "references": [
+          "JST Matt 1:23"
+        ]
+      },
+      {
+        "sign": "Two witnesses prophecy, die, resurrected",
+        "references": [
+          "Revelation 11:2"
+        ]
+      },
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 16:16-21"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Spirits of the devil gather kings of the earth",
+        "references": [
+          "Revelation 16:12-16"
+        ]
+      },
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "Assumption"
+        ]
+      }
+    ]
+  },
+  "Whole earth in commotion": {
+    "name": "Whole earth in commotion",
+    "references": [
+      "Ezekiel 38:18-23",
+      "D&C 45:40-43",
+      "Joel 3:14-16",
+      "JST Matt 1:33",
+      "JST Matt 1:36",
+      "Mark 13:24",
+      "D&C 43:18",
+      "D&C 45:47-48",
+      "D&C 49:23",
+      "Moses 7:60-61",
+      "D&C 45:31-33",
+      "D&C 88:87-93",
+      "Teachings of the Prophet Joseph Smith; p286-287",
+      "Revelation 6:12-17",
+      "D&C 29:14-19",
+      "D&C 34:7-9",
+      "Luke 21:25-28",
+      "Revelation 16:16-21",
+      "Revelation 11:19",
+      "D&C 45:26-27"
+    ],
+    "aliases": [],
+    "members": [
+      "Hail",
+      "Overflowing rain",
+      "Pestilence",
+      "Fire",
+      "Heavens shake",
+      "Earthquakes",
+      "Stars fall from heaven",
+      "Signs in the heavens",
+      "Great earthquake",
+      "Lightenings, voices, thunderings",
+      "Earthquake",
+      "Great hail",
+      "Great hailstorm",
+      "Flies eat flesh and cause maggots",
+      "Blood",
+      "Vapors of smoke",
+      "Thunderings and lightenings",
+      "Tempests",
+      "Tsunamis",
+      "Darkness"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "JST Matt 1:36",
+          "Mark 13:24",
+          "D&C 34:7-9",
+          "Moses 7:60-61",
+          "Luke 21:25-28",
+          "D&C 45:40-43",
+          "D&C 88:87-93",
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      },
+      {
+        "sign": "Angel sounds his trump",
+        "references": [
+          "D&C 29:14-19"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Ezekiel 38:18-23",
+          "JST Matt 1:33",
+          "Mark 13:24"
+        ]
+      },
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "Joel 3:14-16",
+          "D&C 43:18"
+        ]
+      },
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 11:19",
+          "Revelation 16:16-21"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "D&C 45:26-27",
+          "D&C 45:31-33"
+        ]
+      },
+      {
+        "sign": "Mount of Olives splits",
+        "references": [
+          "D&C 45:47-48"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount of Olives",
+        "references": [
+          "D&C 45:47-48"
+        ]
+      },
+      {
+        "sign": "Angel sounds a trump",
+        "references": [
+          "D&C 49:23"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      }
+    ]
+  },
+  "Great earthquake in Israel": {
+    "name": "Great earthquake in Israel",
+    "references": [
+      "Ezekiel 38:18-23",
+      "Revelation 11:13",
+      "Revelation 11:15"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 11:15"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Ezekiel 38:18-23"
+        ]
+      },
+      {
+        "sign": "Two witnesses prophecy, die, resurrected",
+        "references": [
+          "Revelation 11:13"
+        ]
+      }
+    ]
+  },
+  "Gog and Magog defeated": {
+    "name": "Gog and Magog defeated",
+    "references": [
+      "Ezekiel 39",
+      "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+    ],
+    "aliases": [],
+    "members": [
+      "Israel burns enemy weapons for seven years",
+      "Israel will spoil their enemies"
+    ],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Ezekiel 39"
+        ]
+      },
+      {
+        "sign": "Mount of Olives splits",
+        "references": [
+          "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+        ]
+      }
+    ]
+  },
+  "Darkness": {
+    "name": "Darkness",
+    "references": [
+      "Joel 2:31",
+      "Joel 3:14-16",
+      "JST Matt 1:33",
+      "JST Matt 1:36",
+      "Mark 13:24",
+      "Acts 2:20",
+      "D&C 29:14-19",
+      "D&C 34:7-9",
+      "D&C 45:40-43",
+      "D&C 88:87-93",
+      "Moses 7:60-61",
+      "Teachings of the Prophet Joseph Smith; p286-287",
+      "Revelation 6:12-17"
+    ],
+    "aliases": [],
+    "members": [
+      "Sun darkened",
+      "Moon turned to blood",
+      "Moon darkened",
+      "Stars refuse their light",
+      "Darkness shall cover the earth"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "Joel 2:31",
+          "Acts 2:20",
+          "D&C 45:40-43",
+          "JST Matt 1:36",
+          "Teachings of the Prophet Joseph Smith; p286-287",
+          "Mark 13:24",
+          "D&C 34:7-9",
+          "Moses 7:60-61",
+          "D&C 88:87-93"
+        ]
+      },
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "Joel 3:14-16"
+        ]
+      },
+      {
+        "sign": "Angel sounds his trump",
+        "references": [
+          "D&C 29:14-19"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Joel 3:14-16",
+          "JST Matt 1:33",
+          "Mark 13:24"
+        ]
+      },
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      }
+    ]
+  },
+  "Great day of the Lord": {
+    "name": "Great day of the Lord",
+    "references": [
+      "Joel 2:31",
+      "Malachi 4:5",
+      "Acts 2:20",
+      "D&C 45:40-43",
+      "D&C 133:10",
+      "Zechariah 14:5",
+      "JST Matt 1:36",
+      "Mark 13:24",
+      "Luke 21:25-28",
+      "1 Thessalonians 4:16-17",
+      "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8",
+      "D&C 34:7-9",
+      "D&C 63:33-34",
+      "D&C 64:23-24",
+      "D&C 76:63",
+      "D&C 88:95-97",
+      "D&C 88:99",
+      "Moses 7:60-61",
+      "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578",
+      "JST Matt 1:31",
+      "Teachings of the Prophet Joseph Smith; p286-287",
+      "JST Matt 1:37",
+      "D&C 29:13",
+      "D&C 43:18",
+      "D&C 45:45-46",
+      "D&C 133:56",
+      "Assumption",
+      "Revelation 6:12-17",
+      "Revelation 11:19",
+      "2 Nephi 30:8,10",
+      "2 Nephi 30:15-18",
+      "D&C 29:9",
+      "D&C 45:49-50",
+      "D&C 45:54",
+      "D&C 63:54",
+      "D&C 86:7",
+      "D&C 101:23-25",
+      "D&C 88:87-93",
+      "D&C 88:94"
+    ],
+    "aliases": [],
+    "members": [
+      "Christ comes in the clouds",
+      "Burning",
+      "Sign of the Son of Man",
+      "Rapture",
+      "Morning of the First Resurrection",
+      "Curtain of heaven unfolded as a scroll",
+      "Temple of God opened",
+      "Silence for half an hour"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Angels gather the remainder of the elect",
+        "references": [
+          "JST Matt 1:37"
+        ]
+      },
+      {
+        "sign": "Millenium",
+        "references": [
+          "2 Nephi 30:15-18",
+          "D&C 45:54",
+          "D&C 76:63",
+          "D&C 88:99",
+          "D&C 101:23-25",
+          "Assumption"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount Zion",
+        "references": [
+          "D&C 133:56"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Darkness",
+        "references": [
+          "Joel 2:31",
+          "Acts 2:20",
+          "D&C 45:40-43",
+          "JST Matt 1:36",
+          "Teachings of the Prophet Joseph Smith; p286-287",
+          "Mark 13:24",
+          "D&C 34:7-9",
+          "Moses 7:60-61",
+          "D&C 88:87-93"
+        ]
+      },
+      {
+        "sign": "Mount of Olives splits",
+        "references": [
+          "Zechariah 14:5"
+        ]
+      },
+      {
+        "sign": "Restoration",
+        "references": [
+          "Malachi 4:5"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "JST Matt 1:31",
+          "D&C 133:10"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "JST Matt 1:36",
+          "Mark 13:24",
+          "D&C 34:7-9",
+          "Moses 7:60-61",
+          "Luke 21:25-28",
+          "D&C 45:40-43",
+          "D&C 88:87-93",
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      },
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 11:19"
+        ]
+      },
+      {
+        "sign": "Wheat and Tares",
+        "references": [
+          "2 Nephi 30:8,10",
+          "D&C 63:54",
+          "D&C 86:7",
+          "D&C 88:94"
+        ]
+      },
+      {
+        "sign": "Gentiles help gather God's people",
+        "references": [
+          "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+        ]
+      },
+      {
+        "sign": "Gathering of the elect",
+        "references": [
+          "D&C 29:9"
+        ]
+      },
+      {
+        "sign": "Angel sounds his trump",
+        "references": [
+          "D&C 29:13",
+          "D&C 45:45-46"
+        ]
+      },
+      {
+        "sign": "Trump of God shall sound",
+        "references": [
+          "D&C 43:18"
+        ]
+      },
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "D&C 45:40-43"
+        ]
+      },
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "D&C 45:49-50"
+        ]
+      },
+      {
+        "sign": "Wars",
+        "references": [
+          "D&C 63:33-34",
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      },
+      {
+        "sign": "Waters from temple heal the Dead Sea",
+        "references": [
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      },
+      {
+        "sign": "Gathering at Adam-Ondi-Ahman",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      }
+    ]
+  },
+  "Lord speaks from Zion and Jerusalem": {
+    "name": "Lord speaks from Zion and Jerusalem",
+    "references": [
+      "Joel 3:14-16",
+      "D&C 133:21-22",
+      "D&C 133:23",
+      "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578",
+      "D&C 43:18",
+      "D&C 45:49-50"
+    ],
+    "aliases": [
+      "Lord utters his voice out of heaven",
+      "Lord utters his voice"
+    ],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "Joel 3:14-16",
+          "D&C 43:18"
+        ]
+      },
+      {
+        "sign": "Trump of God shall sound",
+        "references": [
+          "D&C 43:18"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 45:49-50"
+        ]
+      },
+      {
+        "sign": "Islands become one land",
+        "references": [
+          "D&C 133:21-22",
+          "D&C 133:23"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Darkness",
+        "references": [
+          "Joel 3:14-16"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount of Olives",
+        "references": [
+          "D&C 45:49-50"
+        ]
+      },
+      {
+        "sign": "Gathering at Adam-Ondi-Ahman",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      }
+    ]
+  },
+  "Half of the city is captive": {
+    "name": "Half of the city is captive",
+    "references": [
+      "Zechariah 14",
+      "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Christ stands on Mount of Olives",
+        "references": [
+          "Zechariah 14"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Zechariah 14"
+        ]
+      },
+      {
+        "sign": "Two witnesses prophecy, die, resurrected",
+        "references": [
+          "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+        ]
+      }
+    ]
+  },
+  "Christ stands on Mount of Olives": {
+    "name": "Christ stands on Mount of Olives",
+    "references": [
+      "Zechariah 14",
+      "D&C 45:47-48",
+      "D&C 45:49-50",
+      "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Mount of Olives splits",
+        "references": [
+          "Zechariah 14",
+          "D&C 45:47-48"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "D&C 45:47-48"
+        ]
+      },
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "D&C 45:49-50"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Half of the city is captive",
+        "references": [
+          "Zechariah 14"
+        ]
+      },
+      {
+        "sign": "Gathering at Adam-Ondi-Ahman",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      }
+    ]
+  },
+  "Mount of Olives splits": {
+    "name": "Mount of Olives splits",
+    "references": [
+      "Zechariah 14",
+      "Zechariah 14:5",
+      "D&C 45:47-48",
+      "D&C 45:51-53",
+      "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Millenium",
+        "references": [
+          "Zechariah 14"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "Zechariah 14:5"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "D&C 45:47-48"
+        ]
+      },
+      {
+        "sign": "Jews recognize Christ",
+        "references": [
+          "D&C 45:51-53"
+        ]
+      },
+      {
+        "sign": "Gog and Magog defeated",
+        "references": [
+          "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Christ stands on Mount of Olives",
+        "references": [
+          "Zechariah 14",
+          "D&C 45:47-48"
+        ]
+      }
+    ]
+  },
+  "Flesh fall off their bones and eyes fall out": {
+    "name": "Flesh fall off their bones and eyes fall out",
+    "references": [
+      "Zechariah 14:12",
+      "D&C 29:14-19"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Angel sounds his trump",
+        "references": [
+          "D&C 29:14-19"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Zechariah 14:12"
+        ]
+      }
+    ]
+  },
+  "False Christs and false prophets": {
+    "name": "False Christs and false prophets",
+    "references": [
+      "JST Matt 1:18,22"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "JST Matt 1:18,22"
+        ]
+      }
+    ]
+  },
+  "Wars": {
+    "name": "Wars",
+    "references": [
+      "JST Matt 1:23",
+      "D&C 45:26-27",
+      "D&C 45:31-33",
+      "D&C 63:33-34",
+      "Teachings of the Prophet Joseph Smith; p286-287"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 63:33-34",
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "JST Matt 1:23"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "D&C 45:26-27",
+          "D&C 45:31-33"
+        ]
+      }
+    ]
+  },
+  "Gospel preached to the world": {
+    "name": "Gospel preached to the world",
+    "references": [
+      "JST Matt 1:31",
+      "Assumption",
+      "1 Nephi 15:13",
+      "1 Nephi 15:17",
+      "D&C 39:11",
+      "D&C 88:87-93",
+      "D&C 133:7-8",
+      "D&C 133:10",
+      "Moses 7:62"
+    ],
+    "aliases": [],
+    "members": [
+      "Gospel preached to all the world",
+      "Fullness of the gospel preached to Lehi's seed",
+      "Gospel preached to the Gentiles",
+      "Elders sent unto the nations",
+      "Elders sent unto the Gentiles",
+      "Elders sent unto the Jews",
+      "Truth sweeps earth as a flood"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "JST Matt 1:31",
+          "D&C 133:10"
+        ]
+      },
+      {
+        "sign": "Gathering of Israel",
+        "references": [
+          "D&C 39:11"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      },
+      {
+        "sign": "Darkness",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      },
+      {
+        "sign": "Times of the Gentiles fulfilled",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      },
+      {
+        "sign": "Gathering of the elect",
+        "references": [
+          "Moses 7:62"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "1 Nephi 15:13",
+          "D&C 39:11",
+          "D&C 88:87-93",
+          "D&C 133:7-8",
+          "Assumption"
+        ]
+      },
+      {
+        "sign": "Pre-Restoration",
+        "references": [
+          "1 Nephi 15:17"
+        ]
+      }
+    ]
+  },
+  "Angels gather the remainder of the elect": {
+    "name": "Angels gather the remainder of the elect",
+    "references": [
+      "JST Matt 1:37"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "JST Matt 1:37"
+        ]
+      }
+    ]
+  },
+  "Opening of the Sixth Seal": {
+    "name": "Opening of the Sixth Seal",
+    "references": [
+      "Revelation 6:12-17",
+      "Revelation 7:2, D&C 77:9",
+      "Revelation 9"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "Darkness",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "Islands become one land",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "Men hide themselves",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "Restoration",
+        "references": [
+          "Revelation 7:2, D&C 77:9"
+        ]
+      },
+      {
+        "sign": "Opening of the Seventh Seal",
+        "references": [
+          "Revelation 9"
+        ]
+      }
+    ],
+    "comesAfter": []
+  },
+  "Islands become one land": {
+    "name": "Islands become one land",
+    "references": [
+      "Revelation 6:12-17",
+      "Revelation 16:16-21",
+      "D&C 133:23",
+      "D&C 133:25",
+      "D&C 49:23",
+      "D&C 133:21-22"
+    ],
+    "aliases": [],
+    "members": [
+      "Every mountain and island moved",
+      "Face of the earth changed",
+      "Mountains broken down",
+      "Ocean driven back into the north countries"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Millenium",
+        "references": [
+          "D&C 133:25"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      },
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 16:16-21"
+        ]
+      },
+      {
+        "sign": "Angel sounds a trump",
+        "references": [
+          "D&C 49:23"
+        ]
+      },
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "D&C 133:21-22",
+          "D&C 133:23"
+        ]
+      }
+    ]
+  },
+  "Men hide themselves": {
+    "name": "Men hide themselves",
+    "references": [
+      "Revelation 6:12-17"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 6:12-17"
+        ]
+      }
+    ]
+  },
+  "Sealing of the 144,000": {
+    "name": "Sealing of the 144,000",
+    "references": [
+      "Revelation 7:3-4",
+      "Revelation 9",
+      "Revelation 14:1",
+      "D&C 133:18"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Opening of the Seventh Seal",
+        "references": [
+          "Revelation 9"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount Zion",
+        "references": [
+          "Revelation 14:1",
+          "D&C 133:18"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "Revelation 7:3-4"
+        ]
+      }
+    ]
+  },
+  "Opening of the Seventh Seal": {
+    "name": "Opening of the Seventh Seal",
+    "references": [
+      "Revelation 9",
+      "Revelation 8:1"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Silence in heavens for half an hour",
+        "references": [
+          "Revelation 8:1"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Opening of the Sixth Seal",
+        "references": [
+          "Revelation 9"
+        ]
+      },
+      {
+        "sign": "Sealing of the 144,000",
+        "references": [
+          "Revelation 9"
+        ]
+      }
+    ]
+  },
+  "Silence in heavens for half an hour": {
+    "name": "Silence in heavens for half an hour",
+    "references": [
+      "Revelation 8:1",
+      "Revelation 8:5"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Voices, Thunderings, Lightenings, Earthquake",
+        "references": [
+          "Revelation 8:5"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Opening of the Seventh Seal",
+        "references": [
+          "Revelation 8:1"
+        ]
+      }
+    ]
+  },
+  "Voices, Thunderings, Lightenings, Earthquake": {
+    "name": "Voices, Thunderings, Lightenings, Earthquake",
+    "references": [
+      "Revelation 8:5",
+      "Revelation 8:7"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Revelation 8-9: Six Trumpets",
+        "references": [
+          "Revelation 8:7"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Silence in heavens for half an hour",
+        "references": [
+          "Revelation 8:5"
+        ]
+      }
+    ]
+  },
+  "Revelation 8-9: Six Trumpets": {
+    "name": "Revelation 8-9: Six Trumpets",
+    "references": [
+      "Revelation 8:7",
+      "Revelation 8:8",
+      "Revelation 8:10",
+      "Revelation 8:12",
+      "Revelation 9:1-12",
+      "Revelation 9:13-21",
+      "Revelation 10"
+    ],
+    "aliases": [],
+    "members": [
+      "1: Hail, fire, blood",
+      "2: Third part of sea becomes blood",
+      "3: Great star falls from heaven causing wormwood",
+      "4: Third part of sun, moon, stars smitten",
+      "5: Smoke and tormenting locusts",
+      "6: Four horsemen kill third of men"
+    ],
+    "comesBefore": [
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 10"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Voices, Thunderings, Lightenings, Earthquake",
+        "references": [
+          "Revelation 8:7"
+        ]
+      }
+    ]
+  },
+  "7: Seven thunders; mystery of God finished": {
+    "name": "7: Seven thunders; mystery of God finished",
+    "references": [
+      "Revelation 10",
+      "Revelation 11:15",
+      "Revelation 11:19",
+      "Revelation 15-16",
+      "Revelation 16:16-21"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "Revelation 11:19"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "Revelation 11:19",
+          "Revelation 16:16-21"
+        ]
+      },
+      {
+        "sign": "Islands become one land",
+        "references": [
+          "Revelation 16:16-21"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Revelation 8-9: Six Trumpets",
+        "references": [
+          "Revelation 10"
+        ]
+      },
+      {
+        "sign": "Great earthquake in Israel",
+        "references": [
+          "Revelation 11:15"
+        ]
+      },
+      {
+        "sign": "Revelation 16: Plagues",
+        "references": [
+          "Revelation 15-16"
+        ]
+      },
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Revelation 16:16-21"
+        ]
+      }
+    ]
+  },
+  "Two witnesses prophecy, die, resurrected": {
+    "name": "Two witnesses prophecy, die, resurrected",
+    "references": [
+      "Revelation 11:2",
+      "Revelation 11:3; 11:7",
+      "D&C 77:15",
+      "Revelation 11:11",
+      "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng",
+      "Revelation 11:13"
+    ],
+    "aliases": [],
+    "members": [
+      "Two witnesses prophecy",
+      "Two witnesses die",
+      "Two witnesses resurrected"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Great earthquake in Israel",
+        "references": [
+          "Revelation 11:13"
+        ]
+      },
+      {
+        "sign": "Half of the city is captive",
+        "references": [
+          "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Revelation 11:2"
+        ]
+      },
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "D&C 77:15"
+        ]
+      }
+    ]
+  },
+  "Christ stands on Mount Zion": {
+    "name": "Christ stands on Mount Zion",
+    "references": [
+      "Revelation 14:1",
+      "D&C 84:2",
+      "D&C 133:18",
+      "D&C 133:56",
+      "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Sealing of the 144,000",
+        "references": [
+          "Revelation 14:1",
+          "D&C 133:18"
+        ]
+      },
+      {
+        "sign": "New Jerusalem",
+        "references": [
+          "D&C 84:2"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 133:56"
+        ]
+      },
+      {
+        "sign": "Gathering at Adam-Ondi-Ahman",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      }
+    ]
+  },
+  "Revelation 16: Plagues": {
+    "name": "Revelation 16: Plagues",
+    "references": [
+      "Revelation 15-16",
+      "Revelation 16:12-16"
+    ],
+    "aliases": [],
+    "members": [
+      "1. Grievous sore",
+      "2. Sea turned to blood",
+      "3. Rivers and fountains turned to blood",
+      "4. Men scorched with heat of the sun",
+      "5. Kingdom of beast full of darkness",
+      "6: Euphrates dried up"
+    ],
+    "comesBefore": [
+      {
+        "sign": "7: Seven thunders; mystery of God finished",
+        "references": [
+          "Revelation 15-16"
+        ]
+      },
+      {
+        "sign": "Spirits of the devil gather kings of the earth",
+        "references": [
+          "Revelation 16:12-16"
+        ]
+      }
+    ],
+    "comesAfter": []
+  },
+  "Spirits of the devil gather kings of the earth": {
+    "name": "Spirits of the devil gather kings of the earth",
+    "references": [
+      "Revelation 16:12-16"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "All nations gathered against Israel",
+        "references": [
+          "Revelation 16:12-16"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Revelation 16: Plagues",
+        "references": [
+          "Revelation 16:12-16"
+        ]
+      }
+    ]
+  },
+  "Jews believe in Christ": {
+    "name": "Jews believe in Christ",
+    "references": [
+      "2 Nephi 10:6-8"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Gathering of the Jews",
+        "references": [
+          "2 Nephi 10:6-8"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Pre-Restoration",
+        "references": [
+          "2 Nephi 10:6-8"
+        ]
+      }
+    ]
+  },
+  "Gathering of the Jews": {
+    "name": "Gathering of the Jews",
+    "references": [
+      "2 Nephi 10:6-8"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Jews believe in Christ",
+        "references": [
+          "2 Nephi 10:6-8"
+        ]
+      }
+    ]
+  },
+  "Wheat and Tares": {
+    "name": "Wheat and Tares",
+    "references": [
+      "2 Nephi 30:8,10",
+      "D&C 63:54",
+      "D&C 86:7",
+      "D&C 88:94"
+    ],
+    "aliases": [],
+    "members": [
+      "Gathering of the wheat",
+      "Tares bound in bundles"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "2 Nephi 30:8,10",
+          "D&C 63:54",
+          "D&C 86:7",
+          "D&C 88:94"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "2 Nephi 30:8,10",
+          "D&C 63:54"
+        ]
+      }
+    ]
+  },
+  "Times of the Gentiles fulfilled": {
+    "name": "Times of the Gentiles fulfilled",
+    "references": [
+      "3 Nephi 16:7-10",
+      "D&C 45:24-25",
+      "D&C 45:26-27",
+      "D&C 45:28-30",
+      "D&C 45:31-33",
+      "3 Nephi 16:10-12",
+      "D&C 88:87-93"
+    ],
+    "aliases": [],
+    "members": [
+      "Gentiles sin against the gospel",
+      "Men's hearts shall fail them",
+      "Shall say that Christ delayeth his coming",
+      "Love of men wax cold",
+      "Iniquity shall abound",
+      "Overflowing scourge, desolating sickness",
+      "Men will curse God and die",
+      "Many desolations"
+    ],
+    "comesBefore": [
+      {
+        "sign": "Gathering of Israel",
+        "references": [
+          "3 Nephi 16:10-12"
+        ]
+      },
+      {
+        "sign": "Wars",
+        "references": [
+          "D&C 45:26-27",
+          "D&C 45:31-33"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "D&C 45:26-27",
+          "D&C 45:31-33"
+        ]
+      },
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "D&C 45:24-25"
+        ]
+      },
+      {
+        "sign": "Restoration",
+        "references": [
+          "D&C 45:28-30"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "D&C 88:87-93"
+        ]
+      }
+    ]
+  },
+  "New Jerusalem": {
+    "name": "New Jerusalem",
+    "references": [
+      "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8",
+      "D&C 84:2",
+      "Moses 7:62",
+      "Moses 7:63-64"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Gentiles help gather God's people",
+        "references": [
+          "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount Zion",
+        "references": [
+          "D&C 84:2"
+        ]
+      },
+      {
+        "sign": "Return of the City of Enoch",
+        "references": [
+          "Moses 7:63-64"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Pre-Restoration",
+        "references": [
+          "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+        ]
+      },
+      {
+        "sign": "Gathering of the elect",
+        "references": [
+          "Moses 7:62"
+        ]
+      }
+    ]
+  },
+  "Gentiles help gather God's people": {
+    "name": "Gentiles help gather God's people",
+    "references": [
+      "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "New Jerusalem",
+        "references": [
+          "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
+        ]
+      }
+    ]
+  },
+  "Gathering of the elect": {
+    "name": "Gathering of the elect",
+    "references": [
+      "D&C 29:7",
+      "D&C 29:9",
+      "D&C 33:6",
+      "Moses 7:62"
+    ],
+    "aliases": [
+      "Gather elect from four quarters of the earth"
+    ],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 29:9"
+        ]
+      },
+      {
+        "sign": "New Jerusalem",
+        "references": [
+          "Moses 7:62"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "D&C 29:7",
+          "D&C 33:6"
+        ]
+      },
+      {
+        "sign": "Gospel preached to the world",
+        "references": [
+          "Moses 7:62"
+        ]
+      }
+    ]
+  },
+  "Angel sounds his trump": {
+    "name": "Angel sounds his trump",
+    "references": [
+      "D&C 29:13",
+      "D&C 29:14-19",
+      "D&C 45:45-46"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 29:13",
+          "D&C 45:45-46"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Darkness",
+        "references": [
+          "D&C 29:14-19"
+        ]
+      },
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "D&C 29:14-19"
+        ]
+      },
+      {
+        "sign": "Flesh fall off their bones and eyes fall out",
+        "references": [
+          "D&C 29:14-19"
+        ]
+      }
+    ]
+  },
+  "Trump of God shall sound": {
+    "name": "Trump of God shall sound",
+    "references": [
+      "D&C 43:18"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "D&C 43:18"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "D&C 43:18"
+        ]
+      }
+    ]
+  },
+  "Times of the Gentiles begins": {
+    "name": "Times of the Gentiles begins",
+    "references": [
+      "D&C 45:28-30"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "D&C 45:28-30"
+        ]
+      }
+    ],
+    "comesAfter": []
+  },
+  "Jews recognize Christ": {
+    "name": "Jews recognize Christ",
+    "references": [
+      "D&C 45:51-53"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "Mount of Olives splits",
+        "references": [
+          "D&C 45:51-53"
+        ]
+      }
+    ]
+  },
+  "Angel sounds a trump": {
+    "name": "Angel sounds a trump",
+    "references": [
+      "D&C 49:23"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Whole earth in commotion",
+        "references": [
+          "D&C 49:23"
+        ]
+      },
+      {
+        "sign": "Islands become one land",
+        "references": [
+          "D&C 49:23"
+        ]
+      }
+    ],
+    "comesAfter": []
+  },
+  "Gathering at Adam-Ondi-Ahman": {
+    "name": "Gathering at Adam-Ondi-Ahman",
+    "references": [
+      "D&C 116",
+      "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount of Olives",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      },
+      {
+        "sign": "Christ stands on Mount Zion",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      },
+      {
+        "sign": "Lord speaks from Zion and Jerusalem",
+        "references": [
+          "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Restoration",
+        "references": [
+          "D&C 116"
+        ]
+      }
+    ]
+  },
+  "Return of the City of Enoch": {
+    "name": "Return of the City of Enoch",
+    "references": [
+      "Moses 7:63-64"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [],
+    "comesAfter": [
+      {
+        "sign": "New Jerusalem",
+        "references": [
+          "Moses 7:63-64"
+        ]
+      }
+    ]
+  },
+  "Temple in Jerusalem rebuilt": {
+    "name": "Temple in Jerusalem rebuilt",
+    "references": [
+      "Teachings of the Prophet Joseph Smith; p286-287"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Waters from temple heal the Dead Sea",
+        "references": [
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Jews gathered in Jerusalem",
+        "references": [
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      }
+    ]
+  },
+  "Waters from temple heal the Dead Sea": {
+    "name": "Waters from temple heal the Dead Sea",
+    "references": [
+      "Teachings of the Prophet Joseph Smith; p286-287"
+    ],
+    "aliases": [],
+    "members": [],
+    "comesBefore": [
+      {
+        "sign": "Great day of the Lord",
+        "references": [
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      }
+    ],
+    "comesAfter": [
+      {
+        "sign": "Temple in Jerusalem rebuilt",
+        "references": [
+          "Teachings of the Prophet Joseph Smith; p286-287"
+        ]
+      }
+    ]
+  }
+}

--- a/data/graph-data.json
+++ b/data/graph-data.json
@@ -30,6 +30,7 @@
       "Lord lifts his hand upon the Gentiles",
       "Marvelous work among the Gentiles"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Remnant shall return to God",
@@ -152,6 +153,7 @@
       "Isaiah 10:20-21"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -182,6 +184,7 @@
       "Fulness of the gospel brought to the house of Israel",
       "Recover the house of Israel"
     ],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -230,6 +233,7 @@
       "All nations gathered unto Jerusalem",
       "Christ shall reign over all flesh"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Judah and Israel come together out of the land of the north",
@@ -277,6 +281,7 @@
       "Jeremiah 3:17-18"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -307,6 +312,7 @@
       "Scattering of the ten tribes",
       "Scattering of the Jews"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Gathering of Israel",
@@ -362,6 +368,7 @@
       "Jeremiah 23:5"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -383,6 +390,7 @@
       "Assumption"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Times of the Gentiles fulfilled",
@@ -452,6 +460,7 @@
       "Multitudes gathered in the valley of decision",
       "Great tribulation of the Jews"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Hail",
@@ -577,6 +586,7 @@
       "Ezekiel 38:18-23"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -595,6 +605,7 @@
       "Revelation 11:15"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "7: Seven thunders; mystery of God finished",
@@ -624,6 +635,7 @@
       "Ezekiel 38:18-23"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -640,6 +652,7 @@
       "Ezekiel 38:18-23"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -657,6 +670,7 @@
       "D&C 45:40-43"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -681,6 +695,7 @@
       "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Israel burns enemy weapons for seven years",
@@ -710,6 +725,7 @@
       "Ezekiel 39"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Israel will spoil their enemies",
@@ -733,6 +749,7 @@
       "Ezekiel 39"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -763,6 +780,7 @@
     "aliases": [
       "Sun turned blacked"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -834,6 +852,7 @@
       "D&C 133:10"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -909,6 +928,7 @@
       "Teachings of the Prophet Joseph Smith; p286-287"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -963,6 +983,7 @@
       "Moses 7:60-61"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Lord speaks from Zion and Jerusalem",
@@ -1009,6 +1030,7 @@
       "Lord utters his voice out of heaven",
       "Lord utters his voice"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Heavens shake",
@@ -1089,6 +1111,7 @@
       "Moses 7:60-61"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -1145,6 +1168,7 @@
       "Teachings of the Prophet Joseph Smith; p286-287"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -1195,6 +1219,7 @@
       "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ stands on Mount of Olives",
@@ -1227,6 +1252,7 @@
       "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Mount of Olives splits",
@@ -1273,6 +1299,7 @@
       "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ reigns as King",
@@ -1322,6 +1349,7 @@
       "D&C 29:14-19"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Angel sounds his trump",
@@ -1361,6 +1389,7 @@
     "aliases": [
       "Son of Man shall come"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Angels gather the remainder of the elect",
@@ -1506,6 +1535,7 @@
       "Assumption"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -1529,6 +1559,7 @@
       "JST Matt 1:18,22"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -1549,6 +1580,7 @@
       "Teachings of the Prophet Joseph Smith; p286-287"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -1589,6 +1621,7 @@
     "aliases": [
       "Preach the fulness of the gospel"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Burning",
@@ -1630,6 +1663,7 @@
     "aliases": [
       "Destruction of the wicked"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "All things revealed",
@@ -1721,6 +1755,7 @@
       "D&C 88:87-93"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -1782,6 +1817,7 @@
     "aliases": [
       "Great sign in heaven"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -1889,6 +1925,7 @@
       "JST Matt 1:37"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -1906,6 +1943,7 @@
       "Teachings of the Prophet Joseph Smith; p286-287"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -1929,6 +1967,7 @@
       "D&C 88:95-97"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -1959,6 +1998,7 @@
       "Assumption"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -2010,6 +2050,7 @@
       "Revelation 9"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great earthquake",
@@ -2075,6 +2116,7 @@
       "Revelation 16:16-21"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2101,6 +2143,7 @@
     "aliases": [
       "Heaven departed as a scroll"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Temple of God opened",
@@ -2143,6 +2186,7 @@
       "Revelation 6:12-17"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2159,6 +2203,7 @@
       "Revelation 6:12-17"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2176,6 +2221,7 @@
       "Revelation 7:3-4"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sealing of the 144,000",
@@ -2202,6 +2248,7 @@
       "D&C 133:18"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Opening of the Seventh Seal",
@@ -2233,6 +2280,7 @@
       "Revelation 8:1"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Silence in heavens for half an hour",
@@ -2263,6 +2311,7 @@
       "Revelation 8:5"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Voices, Thunderings, Lightenings, Earthquake",
@@ -2287,6 +2336,7 @@
       "Revelation 8:7"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "1: Hail, fire, blood",
@@ -2311,6 +2361,7 @@
       "Revelation 8:8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "2: Third part of sea becomes blood",
@@ -2335,6 +2386,7 @@
       "Revelation 8:10"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "3: Great star falls from heaven causing wormwood",
@@ -2359,6 +2411,7 @@
       "Revelation 8:12"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "4: Third part of sun, moon, stars smitten",
@@ -2383,6 +2436,7 @@
       "Revelation 9:1-12"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "5: Smoke and tormenting locusts",
@@ -2407,6 +2461,7 @@
       "Revelation 9:13-21"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "6: Four horsemen kill third of men",
@@ -2431,6 +2486,7 @@
       "Revelation 10"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "7: Seven thunders; mystery of God finished",
@@ -2458,6 +2514,7 @@
       "Revelation 16:16-21"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Temple of God opened",
@@ -2532,6 +2589,7 @@
       "D&C 77:15"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Two witnesses die",
@@ -2563,6 +2621,7 @@
       "https://www.lds.org/manual/old-testament-student-manual-kings-malachi/enrichment-i?lang=eng"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Two witnesses resurrected",
@@ -2593,6 +2652,7 @@
       "Revelation 11:13"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great earthquake in Israel",
@@ -2620,6 +2680,7 @@
     "aliases": [
       "Face of the Lord unveiled"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -2656,6 +2717,7 @@
       "Revelation 11:19"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2673,6 +2735,7 @@
       "D&C 45:47-48"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2696,6 +2759,7 @@
       "Revelation 16:16-21"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2717,6 +2781,7 @@
       "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -2752,6 +2817,7 @@
       "Revelation 15-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "2. Sea turned to blood",
@@ -2768,6 +2834,7 @@
       "Revelation 15-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "3. Rivers and fountains turned to blood",
@@ -2791,6 +2858,7 @@
       "Revelation 15-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "4. Men scorched with heat of the sun",
@@ -2814,6 +2882,7 @@
       "Revelation 15-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "5. Kingdom of beast full of darkness",
@@ -2837,6 +2906,7 @@
       "Revelation 15-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "6: Euphrates dried up",
@@ -2861,6 +2931,7 @@
       "Revelation 16:12-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "7: Seven thunders; mystery of God finished",
@@ -2890,6 +2961,7 @@
       "Revelation 16:12-16"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "All nations gathered against Israel",
@@ -2915,6 +2987,7 @@
       "D&C 133:25"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ reigns as King",
@@ -2947,6 +3020,7 @@
       "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Destruction of the Nephites",
@@ -2982,6 +3056,7 @@
       "Assumption"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Discovering of America",
@@ -3007,6 +3082,7 @@
       "1 Nephi 13:14"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Scattering of Lehi's seed",
@@ -3042,6 +3118,7 @@
       "1 Nephi 13:12"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Discovering of America",
@@ -3061,6 +3138,7 @@
       "1 Nephi 22:8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Fullness of the gospel preached to Lehi's seed",
@@ -3097,6 +3175,7 @@
       "1 Nephi 15:17"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3120,6 +3199,7 @@
       "Assumption"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Scattering of Lehi's seed",
@@ -3149,6 +3229,7 @@
       "2 Nephi 10:6-8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Gathering of the Jews",
@@ -3172,6 +3253,7 @@
       "2 Nephi 10:6-8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3192,6 +3274,7 @@
     "aliases": [
       "Great division"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Burning",
@@ -3227,6 +3310,7 @@
     "aliases": [
       "Secret acts of men revealed"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Satan bound for 1000 years",
@@ -3266,6 +3350,7 @@
       "D&C 45:31-33"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Gentiles sin against the gospel",
@@ -3357,6 +3442,7 @@
       "3 Nephi 16:10-12"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Gathering of Israel",
@@ -3383,6 +3469,7 @@
       "Moses 7:63-64"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Gentiles help gather God's people",
@@ -3424,6 +3511,7 @@
       "3 Nephi 20:22, 3 Nephi 21:23-25, Ether 13:8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -3452,6 +3540,7 @@
     "aliases": [
       "Gather elect from four quarters of the earth"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Burning",
@@ -3490,6 +3579,7 @@
       "D&C 45:45-46"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Morning of the First Resurrection",
@@ -3544,6 +3634,7 @@
       "D&C 29:14-19"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Angel sounds his trump",
@@ -3560,6 +3651,7 @@
       "D&C 29:14-19"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Angel sounds his trump",
@@ -3576,6 +3668,7 @@
       "D&C 34:7-9"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -3592,6 +3685,7 @@
       "D&C 43:18"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Morning of the First Resurrection",
@@ -3615,6 +3709,7 @@
       "D&C 45:26-27"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3632,6 +3727,7 @@
       "D&C 88:87-93"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -3661,6 +3757,7 @@
       "D&C 45:26-27"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3677,6 +3774,7 @@
       "D&C 45:26-27"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3693,6 +3791,7 @@
       "D&C 45:26-27"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3709,6 +3808,7 @@
       "D&C 45:28-30"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Restoration",
@@ -3725,6 +3825,7 @@
       "D&C 45:31-33"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3741,6 +3842,7 @@
       "D&C 45:31-33"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3757,6 +3859,7 @@
       "D&C 45:31-33"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3773,6 +3876,7 @@
       "D&C 45:40-43"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -3789,6 +3893,7 @@
       "D&C 45:40-43"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -3805,6 +3910,7 @@
       "D&C 45:51-53"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3821,6 +3927,7 @@
       "D&C 45:54"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3842,6 +3949,7 @@
     "aliases": [
       "Afternoon of the First Resurrection"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Third trump: Redemption of Telestial spirits",
@@ -3881,6 +3989,7 @@
     "aliases": [
       "Satan shall be bound"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Satan loosed for a little season",
@@ -3910,6 +4019,7 @@
       "D&C 49:23"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Heavens shake",
@@ -3938,6 +4048,7 @@
       "D&C 49:23"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -3955,6 +4066,7 @@
       "D&C 88:94"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Burning",
@@ -3984,6 +4096,7 @@
       "D&C 88:87-93"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Earthquakes",
@@ -4049,6 +4162,7 @@
       "D&C 88:87-93"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -4072,6 +4186,7 @@
       "D&C 88:87-93"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -4098,6 +4213,7 @@
     "aliases": [
       "Seas heaving beyond their bounds"
     ],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",
@@ -4123,6 +4239,7 @@
       "D&C 88:95-97"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Curtain of heaven unfolded as a scroll",
@@ -4153,6 +4270,7 @@
       "D&C 88:102"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Fourth trump: Sons of perdition",
@@ -4177,6 +4295,7 @@
       "D&C 88:103-104"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Fifth trump: Angel committeth the everlasting gospel",
@@ -4200,6 +4319,7 @@
       "D&C 88:103-104"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Every ear hear; every knee bow; every tongue confess",
@@ -4224,6 +4344,7 @@
       "D&C 88:105"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sixth trump: she is fallen",
@@ -4248,6 +4369,7 @@
       "D&C 88:106"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Seventh trump: It is finished",
@@ -4272,6 +4394,7 @@
       "D&C 88:107"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Angels crowned with glory",
@@ -4302,6 +4425,7 @@
       "D&C 88:108-110"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "All things revealed",
@@ -4326,6 +4450,7 @@
       "D&C 88:108-110"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "All things revealed",
@@ -4349,6 +4474,7 @@
       "D&C 88:111-115"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Satan gathers his armies",
@@ -4378,6 +4504,7 @@
       "D&C 88:111-115"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Satan is defeated and cast away",
@@ -4401,6 +4528,7 @@
       "D&C 88:111-115"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Satan is defeated and cast away",
@@ -4424,6 +4552,7 @@
       "D&C 88:111-115"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -4446,6 +4575,7 @@
       "D&C 101:23-25"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -4463,6 +4593,7 @@
       "The Millennial Messiah by Bruce R McConkie (Salt Lake City: Deseret Book, 1982), pp.578"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -4504,6 +4635,7 @@
       "D&C 133:7-8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Elders sent unto the Gentiles",
@@ -4527,6 +4659,7 @@
       "D&C 133:7-8"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Elders sent unto the Jews",
@@ -4551,6 +4684,7 @@
       "D&C 133:10"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Great day of the Lord",
@@ -4574,6 +4708,7 @@
       "D&C 133:21-22"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -4590,6 +4725,7 @@
       "D&C 133:23"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Islands become one land",
@@ -4614,6 +4750,7 @@
       "D&C 133:27"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "A highway shall be cast up in the ocean",
@@ -4638,6 +4775,7 @@
       "D&C 133:30"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Those in the north countries shall bring their rich treasures to Ephraim",
@@ -4662,6 +4800,7 @@
       "D&C 133:32"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Those in the north countries shall be crowned with glory by Ephraim",
@@ -4685,6 +4824,7 @@
       "D&C 133:32"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -4701,6 +4841,7 @@
       "Moses 7:60-61"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Christ comes in the clouds",
@@ -4717,6 +4858,7 @@
       "Moses 7:62"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Gathering of the elect",
@@ -4733,6 +4875,7 @@
       "Moses 7:63-64"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [],
     "comesAfter": [
       {
@@ -4749,6 +4892,7 @@
       "Teachings of the Prophet Joseph Smith; p286-287"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Waters from temple heal the Dead Sea",
@@ -4772,6 +4916,7 @@
       "Teachings of the Prophet Joseph Smith; p286-287"
     ],
     "aliases": [],
+    "members": [],
     "comesBefore": [
       {
         "sign": "Sign of the Son of Man",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,8 @@ import {
   Popover,
   Paper,
   Chip,
-  Divider,
+  ToggleButtonGroup,
+  ToggleButton,
   Link as MuiLink,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
@@ -17,9 +18,11 @@ import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import Link from 'next/link';
 import { GetStaticProps } from 'next';
-import graphDataImport from '../data/graph-data.json';
+import graphDataFull from '../data/graph-data.json';
+import graphDataSimple from '../data/graph-data-simple.json';
 
 const MIN_ZOOM = 0.1;
 const MAX_ZOOM = 3;
@@ -29,6 +32,7 @@ interface SignDetail {
   name: string;
   references: string[];
   aliases: string[];
+  members?: string[];
   comesBefore: { sign: string; references: string[] }[];
   comesAfter: { sign: string; references: string[] }[];
 }
@@ -38,18 +42,23 @@ interface GraphData {
 }
 
 interface Props {
-  graphData: GraphData;
+  fullGraphData: GraphData;
+  simpleGraphData: GraphData;
 }
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
   return {
     props: {
-      graphData: graphDataImport as GraphData,
+      fullGraphData: graphDataFull as GraphData,
+      simpleGraphData: graphDataSimple as GraphData,
     },
   };
 };
 
-export default function Home({ graphData }: Props) {
+type GraphMode = 'full' | 'simple';
+
+export default function Home({ fullGraphData, simpleGraphData }: Props) {
+  const [graphMode, setGraphMode] = useState<GraphMode>('simple');
   const [zoom, setZoom] = useState(0.5);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
@@ -60,13 +69,17 @@ export default function Home({ graphData }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgContainerRef = useRef<HTMLDivElement>(null);
 
+  const graphData = graphMode === 'full' ? fullGraphData : simpleGraphData;
+  const svgPath = graphMode === 'full' ? '/graph.svg' : '/graph-simple.svg';
+
   // Load SVG content
   useEffect(() => {
-    fetch('/graph.svg')
+    setSvgContent(''); // Clear while loading
+    fetch(svgPath)
       .then((res) => res.text())
       .then((svg) => setSvgContent(svg))
       .catch((err) => console.error('Failed to load SVG:', err));
-  }, []);
+  }, [svgPath]);
 
   // Attach event handlers to SVG nodes
   useEffect(() => {
@@ -76,7 +89,7 @@ export default function Home({ graphData }: Props) {
     const nodes = container.querySelectorAll('.node');
 
     const handleNodeClick = (e: Event) => {
-      const node = (e.currentTarget as Element);
+      const node = e.currentTarget as Element;
       const title = node.querySelector('title')?.textContent;
       if (title && graphData[title]) {
         setSelectedSign(graphData[title]);
@@ -125,6 +138,14 @@ export default function Home({ graphData }: Props) {
     };
   }, [svgContent, graphData]);
 
+  const handleGraphModeChange = (_: React.MouseEvent, newMode: GraphMode | null) => {
+    if (newMode) {
+      setGraphMode(newMode);
+      setSelectedSign(null);
+      setPopoverAnchor(null);
+    }
+  };
+
   const handleZoomIn = useCallback(() => {
     setZoom((z) => Math.min(MAX_ZOOM, z + ZOOM_STEP));
   }, []);
@@ -147,7 +168,6 @@ export default function Home({ graphData }: Props) {
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (e.button !== 0) return;
-    // Don't start drag if clicking on a node
     if ((e.target as Element).closest('.node')) return;
 
     const container = containerRef.current;
@@ -225,6 +245,8 @@ export default function Home({ graphData }: Props) {
           alignItems: 'center',
           justifyContent: 'space-between',
           backgroundColor: 'background.paper',
+          flexWrap: 'wrap',
+          gap: 1,
         }}
       >
         <Box>
@@ -240,30 +262,52 @@ export default function Home({ graphData }: Props) {
           </Typography>
         </Box>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Typography
-            variant="body2"
-            sx={{ color: 'text.secondary', minWidth: 50, textAlign: 'right' }}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          {/* Graph mode toggle */}
+          <ToggleButtonGroup
+            value={graphMode}
+            exclusive
+            onChange={handleGraphModeChange}
+            size="small"
           >
-            {Math.round(zoom * 100)}%
-          </Typography>
-          <ButtonGroup size="small" variant="outlined">
-            <Tooltip title="Zoom out">
-              <IconButton onClick={handleZoomOut} disabled={zoom <= MIN_ZOOM} size="small">
-                <RemoveIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Reset zoom">
-              <IconButton onClick={handleZoomReset} size="small">
-                <RestartAltIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Zoom in">
-              <IconButton onClick={handleZoomIn} disabled={zoom >= MAX_ZOOM} size="small">
-                <AddIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          </ButtonGroup>
+            <ToggleButton value="simple">
+              <Tooltip title="Simplified (groups collapsed)">
+                <span>Simple</span>
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton value="full">
+              <Tooltip title="Full (all signs)">
+                <span>Full</span>
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
+
+          {/* Zoom controls */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography
+              variant="body2"
+              sx={{ color: 'text.secondary', minWidth: 50, textAlign: 'right' }}
+            >
+              {Math.round(zoom * 100)}%
+            </Typography>
+            <ButtonGroup size="small" variant="outlined">
+              <Tooltip title="Zoom out">
+                <IconButton onClick={handleZoomOut} disabled={zoom <= MIN_ZOOM} size="small">
+                  <RemoveIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Reset zoom">
+                <IconButton onClick={handleZoomReset} size="small">
+                  <RestartAltIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Zoom in">
+                <IconButton onClick={handleZoomIn} disabled={zoom >= MAX_ZOOM} size="small">
+                  <AddIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </ButtonGroup>
+          </Box>
         </Box>
       </Box>
 
@@ -324,10 +368,23 @@ export default function Home({ graphData }: Props) {
               </IconButton>
             </Box>
 
-            {selectedSign.aliases.length > 0 && (
+            {selectedSign.aliases && selectedSign.aliases.length > 0 && (
               <Typography variant="body2" sx={{ color: 'text.secondary', mb: 1 }}>
                 Also known as: {selectedSign.aliases.join(', ')}
               </Typography>
+            )}
+
+            {selectedSign.members && selectedSign.members.length > 0 && (
+              <Box sx={{ mb: 2 }}>
+                <Typography variant="subtitle2" sx={{ mb: 0.5, display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <AccountTreeIcon fontSize="small" /> Group members
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {selectedSign.members.map((member, i) => (
+                    <Chip key={i} label={member} size="small" variant="outlined" />
+                  ))}
+                </Box>
+              </Box>
             )}
 
             {selectedSign.references.length > 0 && (

--- a/scripts/generate-graph.js
+++ b/scripts/generate-graph.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 /**
- * Generate a Graphviz DOT file, SVG, and sign details JSON from data.
+ * Generate Graphviz DOT files, SVGs, and sign details JSON from data.
  * 
  * Usage: node scripts/generate-graph.js
- * Output: public/graph.svg, public/graph-data.json
+ * Output: 
+ *   - public/graph.svg (full graph)
+ *   - public/graph-simple.svg (simplified graph with groups collapsed)
+ *   - data/graph-data.json (full graph data)
+ *   - data/graph-data-simple.json (simplified graph data)
  */
 
 const fs = require('fs');
@@ -12,9 +16,16 @@ const { execSync } = require('child_process');
 
 // Load data
 const dataDir = path.join(__dirname, '..', 'data');
+const publicDir = path.join(__dirname, '..', 'public');
+
 const signs = JSON.parse(fs.readFileSync(path.join(dataDir, 'signs.json'), 'utf8'));
 const relationships = JSON.parse(fs.readFileSync(path.join(dataDir, 'relationships.json'), 'utf8'));
 const synonyms = JSON.parse(fs.readFileSync(path.join(dataDir, 'synonyms.json'), 'utf8'));
+const groups = JSON.parse(fs.readFileSync(path.join(dataDir, 'groups.json'), 'utf8'));
+
+if (!fs.existsSync(publicDir)) {
+  fs.mkdirSync(publicDir, { recursive: true });
+}
 
 // Build synonym map: duplicate -> canonical name
 const synonymMap = new Map();
@@ -22,8 +33,16 @@ for (const { duplicate, synonym } of synonyms) {
   synonymMap.set(duplicate, synonym);
 }
 
+// Build group map: member -> group name
+const groupMap = new Map();
+for (const group of groups) {
+  for (const member of group.members) {
+    groupMap.set(member, group.name);
+  }
+}
+
 // Resolve a sign name to its canonical form (following synonym chains)
-function resolve(name) {
+function resolveSynonym(name) {
   const visited = new Set();
   while (synonymMap.has(name) && !visited.has(name)) {
     visited.add(name);
@@ -32,83 +51,15 @@ function resolve(name) {
   return name;
 }
 
-// Build sign details map
-const signDetails = new Map();
-
-// Initialize with sign data
-for (const sign of signs) {
-  const canonical = resolve(sign.name);
-  if (!signDetails.has(canonical)) {
-    signDetails.set(canonical, {
-      name: canonical,
-      references: [],
-      aliases: [],
-      comesBefore: [], // {sign, references}
-      comesAfter: [],  // {sign, references}
-    });
+// Resolve a sign name through synonyms AND groups
+function resolveSimplified(name) {
+  // First resolve synonyms
+  name = resolveSynonym(name);
+  // Then check if it's part of a group
+  if (groupMap.has(name)) {
+    return groupMap.get(name);
   }
-  const detail = signDetails.get(canonical);
-  // Add references from sign
-  for (const ref of sign.references) {
-    if (!detail.references.includes(ref)) {
-      detail.references.push(ref);
-    }
-  }
-  // Track aliases
-  if (sign.name !== canonical && !detail.aliases.includes(sign.name)) {
-    detail.aliases.push(sign.name);
-  }
-}
-
-// Build edges with resolved names, deduplicating
-const edges = new Map();
-for (const rel of relationships) {
-  const before = resolve(rel.before);
-  const after = resolve(rel.after);
-  
-  // Skip self-loops
-  if (before === after) continue;
-  
-  const key = `${before}|||${after}`;
-  if (!edges.has(key)) {
-    edges.set(key, { before, after, references: [] });
-  }
-  edges.get(key).references.push(...rel.references);
-}
-
-// Add relationship data to sign details
-for (const { before, after, references } of edges.values()) {
-  // Ensure both signs exist in details
-  if (!signDetails.has(before)) {
-    signDetails.set(before, {
-      name: before,
-      references: [],
-      aliases: [],
-      comesBefore: [],
-      comesAfter: [],
-    });
-  }
-  if (!signDetails.has(after)) {
-    signDetails.set(after, {
-      name: after,
-      references: [],
-      aliases: [],
-      comesBefore: [],
-      comesAfter: [],
-    });
-  }
-
-  // "before" comes before "after"
-  signDetails.get(before).comesBefore.push({
-    sign: after,
-    references: [...new Set(references)],
-  });
-
-  // "after" comes after "before"
-  signDetails.get(after).comesAfter.push({
-    sign: before,
-    references: [...new Set(references)],
-  });
+  return name;
 }
 
 // Escape label for DOT format
@@ -116,62 +67,204 @@ function escapeLabel(str) {
   return str.replace(/"/g, '\\"').replace(/\n/g, '\\n');
 }
 
-// Generate DOT file
-let dot = `digraph signs_of_the_second_coming {
+// Generate graph data and DOT file
+function generateGraph(resolveFn, isSimplified = false) {
+  const signDetails = new Map();
+  const edges = new Map();
+
+  // Initialize with sign data
+  for (const sign of signs) {
+    const canonical = resolveFn(sign.name);
+    if (!signDetails.has(canonical)) {
+      signDetails.set(canonical, {
+        name: canonical,
+        references: [],
+        aliases: [],
+        members: [], // For groups
+        comesBefore: [],
+        comesAfter: [],
+      });
+    }
+    const detail = signDetails.get(canonical);
+    
+    // Add references from sign
+    for (const ref of sign.references) {
+      if (!detail.references.includes(ref)) {
+        detail.references.push(ref);
+      }
+    }
+    
+    // Track aliases/members
+    if (sign.name !== canonical) {
+      const resolvedName = resolveSynonym(sign.name);
+      if (isSimplified && groupMap.has(resolvedName)) {
+        // It's a group member
+        if (!detail.members.includes(resolvedName)) {
+          detail.members.push(resolvedName);
+        }
+      } else if (!detail.aliases.includes(sign.name)) {
+        detail.aliases.push(sign.name);
+      }
+    }
+  }
+
+  // If simplified, also add group members that might not be in signs
+  if (isSimplified) {
+    for (const group of groups) {
+      if (!signDetails.has(group.name)) {
+        signDetails.set(group.name, {
+          name: group.name,
+          references: [],
+          aliases: [],
+          members: [],
+          comesBefore: [],
+          comesAfter: [],
+        });
+      }
+      const detail = signDetails.get(group.name);
+      for (const member of group.members) {
+        const resolved = resolveSynonym(member);
+        if (!detail.members.includes(resolved)) {
+          detail.members.push(resolved);
+        }
+      }
+    }
+  }
+
+  // Build edges with resolved names, deduplicating
+  for (const rel of relationships) {
+    const before = resolveFn(rel.before);
+    const after = resolveFn(rel.after);
+    
+    // Skip self-loops
+    if (before === after) continue;
+    
+    const key = `${before}|||${after}`;
+    if (!edges.has(key)) {
+      edges.set(key, { before, after, references: [] });
+    }
+    edges.get(key).references.push(...rel.references);
+  }
+
+  // Add relationship data to sign details
+  for (const { before, after, references } of edges.values()) {
+    // Ensure both signs exist in details
+    if (!signDetails.has(before)) {
+      signDetails.set(before, {
+        name: before,
+        references: [],
+        aliases: [],
+        members: [],
+        comesBefore: [],
+        comesAfter: [],
+      });
+    }
+    if (!signDetails.has(after)) {
+      signDetails.set(after, {
+        name: after,
+        references: [],
+        aliases: [],
+        members: [],
+        comesBefore: [],
+        comesAfter: [],
+      });
+    }
+
+    // "before" comes before "after"
+    signDetails.get(before).comesBefore.push({
+      sign: after,
+      references: [...new Set(references)],
+    });
+
+    // "after" comes after "before"
+    signDetails.get(after).comesAfter.push({
+      sign: before,
+      references: [...new Set(references)],
+    });
+  }
+
+  // Generate DOT file
+  let dot = `digraph signs_of_the_second_coming {
   rankdir=TB;
-  node [shape=box, style="rounded,filled", fillcolor="#f0f0f0", fontname="Arial"];
+  node [shape=box, style="rounded,filled", fillcolor="${isSimplified ? '#e3f2fd' : '#f0f0f0'}", fontname="Arial"];
   edge [fontname="Arial", fontsize=10];
   
 `;
 
-// Add nodes
-for (const name of signDetails.keys()) {
-  dot += `  "${escapeLabel(name)}";\n`;
+  // Add nodes
+  for (const name of signDetails.keys()) {
+    dot += `  "${escapeLabel(name)}";\n`;
+  }
+
+  dot += '\n';
+
+  // Add edges
+  for (const { before, after } of edges.values()) {
+    dot += `  "${escapeLabel(before)}" -> "${escapeLabel(after)}";\n`;
+  }
+
+  dot += '}\n';
+
+  return { signDetails, edges, dot };
 }
 
-dot += '\n';
+// Generate full graph
+console.log('Generating full graph...');
+const full = generateGraph(resolveSynonym, false);
 
-// Add edges
-for (const { before, after } of edges.values()) {
-  dot += `  "${escapeLabel(before)}" -> "${escapeLabel(after)}";\n`;
-}
+const fullDotPath = path.join(publicDir, 'graph.dot');
+const fullSvgPath = path.join(publicDir, 'graph.svg');
+const fullJsonPath = path.join(dataDir, 'graph-data.json');
 
-dot += '}\n';
+fs.writeFileSync(fullDotPath, full.dot);
+console.log(`Generated: ${fullDotPath}`);
 
-// Write files
-const publicDir = path.join(__dirname, '..', 'public');
-if (!fs.existsSync(publicDir)) {
-  fs.mkdirSync(publicDir, { recursive: true });
-}
-
-const dotPath = path.join(publicDir, 'graph.dot');
-const svgPath = path.join(publicDir, 'graph.svg');
-const jsonPath = path.join(dataDir, 'graph-data.json');
-
-fs.writeFileSync(dotPath, dot);
-console.log(`Generated: ${dotPath}`);
-
-// Generate SVG using Graphviz
 try {
-  execSync(`dot -Tsvg "${dotPath}" -o "${svgPath}"`, { stdio: 'inherit' });
-  console.log(`Generated: ${svgPath}`);
+  execSync(`dot -Tsvg "${fullDotPath}" -o "${fullSvgPath}"`, { stdio: 'inherit' });
+  console.log(`Generated: ${fullSvgPath}`);
 } catch (error) {
   console.error('Failed to generate SVG. Is Graphviz installed?');
-  console.error('Install with: sudo apt-get install graphviz');
   process.exit(1);
 }
 
-// Convert signDetails map to object for JSON
-const graphData = {};
-for (const [name, detail] of signDetails) {
-  graphData[name] = detail;
+const fullGraphData = {};
+for (const [name, detail] of full.signDetails) {
+  fullGraphData[name] = detail;
+}
+fs.writeFileSync(fullJsonPath, JSON.stringify(fullGraphData, null, 2));
+console.log(`Generated: ${fullJsonPath}`);
+
+console.log(`\nFull graph stats:`);
+console.log(`  Signs: ${full.signDetails.size}`);
+console.log(`  Relationships: ${full.edges.size}`);
+
+// Generate simplified graph
+console.log('\nGenerating simplified graph...');
+const simple = generateGraph(resolveSimplified, true);
+
+const simpleDotPath = path.join(publicDir, 'graph-simple.dot');
+const simpleSvgPath = path.join(publicDir, 'graph-simple.svg');
+const simpleJsonPath = path.join(dataDir, 'graph-data-simple.json');
+
+fs.writeFileSync(simpleDotPath, simple.dot);
+console.log(`Generated: ${simpleDotPath}`);
+
+try {
+  execSync(`dot -Tsvg "${simpleDotPath}" -o "${simpleSvgPath}"`, { stdio: 'inherit' });
+  console.log(`Generated: ${simpleSvgPath}`);
+} catch (error) {
+  console.error('Failed to generate simplified SVG.');
+  process.exit(1);
 }
 
-fs.writeFileSync(jsonPath, JSON.stringify(graphData, null, 2));
-console.log(`Generated: ${jsonPath}`);
+const simpleGraphData = {};
+for (const [name, detail] of simple.signDetails) {
+  simpleGraphData[name] = detail;
+}
+fs.writeFileSync(simpleJsonPath, JSON.stringify(simpleGraphData, null, 2));
+console.log(`Generated: ${simpleJsonPath}`);
 
-// Stats
-console.log(`\nStats:`);
-console.log(`  Signs: ${signDetails.size}`);
-console.log(`  Relationships: ${edges.size}`);
-console.log(`  Synonyms applied: ${synonyms.length}`);
+console.log(`\nSimplified graph stats:`);
+console.log(`  Signs: ${simple.signDetails.size}`);
+console.log(`  Relationships: ${simple.edges.size}`);
+console.log(`  Groups applied: ${groups.length}`);


### PR DESCRIPTION
## Summary
Adds a simplified graph view that collapses group members into single nodes for an easier overview.

## Features
- **Toggle**: Simple/Full buttons in header to switch views
- **Simplified graph**: Groups collapsed into single nodes
- **Popover updates**: Shows group members when clicking a group node
- **Default view**: Starts with simplified for easier overview

## Stats
| Graph | Signs | Relationships |
|-------|-------|---------------|
| Full | 145 | 238 |
| Simplified | 52 | 108 |

15 groups applied to create the simplified view.

## Test
```bash
npm run build:static
npx serve out
```
Toggle between Simple/Full in the header to compare views.